### PR TITLE
Fix md5 import

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1,7 +1,7 @@
 import _fs from 'fs';
 import rimraf from './rimraf';
 import { mkdir } from './util';
-import _md5 from 'MD5';
+import _md5 from 'md5';
 import _ncp from 'ncp';
 import B from 'bluebird';
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "keywords": [
     "appium"
   ],
-  "version": "2.0.0-beta14",
+  "version": "2.0.0-beta15",
   "author": "appium",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
I messed up the import for `md5` when upgrading, which only seemed to cause problems in Travis. This fixes that and bumps version.