### PR TITLE
Added mustExist flag to parsePlistFile

### DIFF
--- a/lib/plist.js
+++ b/lib/plist.js
@@ -15,9 +15,19 @@ async function parseXmlPlistFile (plistFilename) {
   return  xmlplist.parse(xmlContent);
 }
 
-async function parsePlistFile (plist) {
+async function parsePlistFile (plist, mustExist = true) {
   log.debug(`Attempting to parse plist file '${plist}'`);
-  let obj;
+  let obj = {}; 
+  let exists = await fs.exists(plist);
+  // handle nonexistant file
+  if (!exists) {
+    if (mustExist) {
+      log.errorAndThrow(`plist file doesn't exist`);            
+    } else {
+      log.debug(`File doesn't exist. Returning an empty plist.`);
+      return obj;
+    }
+  }
   try {
     obj = await parseFile(plist);
   } catch (ign) {
@@ -39,11 +49,11 @@ async function parsePlistFile (plist) {
   }
 }
 
-async function updatePlistFile (plist, updatedFields, binary = true) {
+async function updatePlistFile (plist, updatedFields, binary = true, mustExist = true) {
   log.debug(`Attempting to update plist file'${plist}'`);
   let obj;
   try {
-    obj = await parsePlistFile(plist);
+    obj = await parsePlistFile(plist, mustExist);
   } catch (err) {
     log.errorAndThrow(`Could not update plist: ${err.message}`);
   }

--- a/test/plist-specs.js
+++ b/test/plist-specs.js
@@ -12,6 +12,13 @@ describe('plist', () => {
     let content = await plist.parsePlistFile(plistPath);
     content.should.have.property('com.apple.locationd.bundle-/System/Library/PrivateFrameworks/Parsec.framework');
   });
+  
+  it(`should return an empty object if file doesn't exist and mustExist is set to false`, async () => {
+    let mustExist = false;
+    let content = await plist.parsePlistFile('doesntExist.plist', mustExist);
+    content.should.be.an.Object;
+    content.should.be.empty;
+  });
 
   it('should write plist file as binary', async () => {
     // create a temporary file, to which we will write


### PR DESCRIPTION
In some cases, we don't want an error thrown if a plist file doesn't exist.

Please review @jlipps 