### PR TITLE
add fs.read function to fs promisified functions

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -41,8 +41,8 @@ let fs = {
 };
 
 const simples = ['open', 'close', 'access', 'readFile', 'writeFile',
-                 'write', 'readlink', 'chmod', 'unlink', 'readdir', 'stat',
-                 'rename', 'lstat'];
+                 'write', 'read', 'readlink', 'chmod', 'unlink', 'readdir',
+                 'stat', 'rename', 'lstat'];
 
 for (let s of simples) {
   fs[s] = B.promisify(_fs[s]);


### PR DESCRIPTION
node-adb-client makes use of `fs.read` to read specific chunk sizes from a file