### PR TITLE
Await on the returned Promise from mkdir

### DIFF
--- a/lib/tempdir.js
+++ b/lib/tempdir.js
@@ -17,7 +17,7 @@ async function tempDir () {
     (Math.random() * 0x100000000 + 1).toString(36)].join(''));
   // creates a temp directory using the date and a random string
 
-  fs.mkdir(filePath);
+  await fs.mkdir(filePath);
 
   return filePath;
 }


### PR DESCRIPTION
Avoids race condition where code run later expects there to be a tmp directory prepared.