### PR TITLE
Allow macOS 10.12 to be found

### DIFF
--- a/lib/system.js
+++ b/lib/system.js
@@ -34,7 +34,7 @@ async function macOsxVersion () {
   } catch (err) {
     throw new Error(`Could not detect Mac OS X Version: ${err}`);
   }
-  for (let v of ['10.8', '10.9', '10.10', '10.11']) {
+  for (let v of ['10.8', '10.9', '10.10', '10.11', '10.12']) {
     if (stdout.indexOf(v) === 0) { return v; }
   }
   throw new Error(`Could not detect Mac OS X Version from sw_vers output: '${stdout}'`);

--- a/test/system-specs.js
+++ b/test/system-specs.js
@@ -53,6 +53,11 @@ describe('system', () => {
       await system.macOsxVersion().should.eventually.equal('10.10');
     });
 
+    it('should return correct version for 10.12', async () => {
+      tpMock.expects('exec').once().withExactArgs('sw_vers', ['-productVersion']).returns({stdout: '10.12.0'});
+      await system.macOsxVersion().should.eventually.equal('10.12');
+    });
+
     it("should throw an error if OSX version can't be determined", async () => {
       let invalidOsx = '99.99.99';
       tpMock.expects('exec').once().withExactArgs('sw_vers', ['-productVersion']).returns({stdout: invalidOsx});


### PR DESCRIPTION
Add latest macOS release to list of acceptable versions. While this will not necessarily mean that macOS 10.12 is supported, it at least means that it will not be stopped by simple checks for validity.

Addresses https://github.com/appium/appium/issues/6609