### PR TITLE
Add trim to mac version check

### DIFF
--- a/lib/system.js
+++ b/lib/system.js
@@ -30,7 +30,7 @@ async function arch () {
 async function macOsxVersion () {
   let stdout;
   try {
-    stdout = (await exec('sw_vers', ['-productVersion'])).stdout;
+    stdout = (await exec('sw_vers', ['-productVersion'])).stdout.trim();
   } catch (err) {
     throw new Error(`Could not detect Mac OS X Version: ${err}`);
   }

--- a/test/system-specs.js
+++ b/test/system-specs.js
@@ -58,6 +58,11 @@ describe('system', () => {
       await system.macOsxVersion().should.eventually.equal('10.12');
     });
 
+    it('should return correct version for 10.12 with newline', async () => {
+      tpMock.expects('exec').once().withExactArgs('sw_vers', ['-productVersion']).returns({stdout: '10.12   \n'});
+      await system.macOsxVersion().should.eventually.equal('10.12');
+    });
+
     it("should throw an error if OSX version can't be determined", async () => {
       let invalidOsx = '99.99.99';
       tpMock.expects('exec').once().withExactArgs('sw_vers', ['-productVersion']).returns({stdout: invalidOsx});


### PR DESCRIPTION
It seems that on macOS the output sometimes has spaces and a newline at the end (see output in https://github.com/appium/appium/issues/6609#issuecomment-252304758). Use `trim()` to get rid of that.