### PR TITLE
Use os.tmpdir instead of tmpDir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-  - "0.12"
+  - "4"
+  - "6"
+  - "7"
 sudo: false
 after_success:
   - gulp coveralls

--- a/lib/tempdir.js
+++ b/lib/tempdir.js
@@ -9,7 +9,7 @@ const RDWR_EXCL = cnst.O_CREAT | cnst.O_TRUNC | cnst.O_RDWR | cnst.O_EXCL;
 
 async function tempDir () {
   let now = new Date();
-  let filePath = nodePath.join(os.tmpDir(),
+  let filePath = nodePath.join(os.tmpdir(),
     [now.getFullYear(), now.getMonth(), now.getDate(),
     '-',
     process.pid,


### PR DESCRIPTION
Node 7 deprecated `tmpDir`. `tmpdir` is available in all the versions we support (https://nodejs.org/api/os.html#os_os_tmpdir).