### PR TITLE
Add helpers for process management

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,9 @@ import fs from './lib/fs';
 import * as plist from './lib/plist';
 import { mkdirp } from './lib/mkdirp';
 import * as logger from './lib/logging';
+import * as process from './lib/process';
 
 // can't add to other exports `as default`
 // until JSHint figures out how to parse that pattern
 export default { tempDir, system, util, fs, cancellableDelay, plist, mkdirp,
-                 logger};
+                 logger, process };

--- a/lib/process.js
+++ b/lib/process.js
@@ -1,0 +1,44 @@
+import { exec } from 'teen_process';
+
+
+/*
+ * Exit Status for pgrep and pkill (`man pkill`)
+ *  0. One or more processes matched the criteria.
+ *  1. No processes matched.
+ *  2. Syntax error in the command line.
+ *  3. Fatal error: out of memory etc.
+ */
+
+async function getProcessIds (appName) {
+  let pids;
+  try {
+    let {stdout} = await exec('pgrep', ['-x', appName]);
+    pids = stdout.trim().split('\n').map((pid) => parseInt(pid, 10));
+  } catch (err) {
+    if (parseInt(err.code, 10) !== 1) {
+      throw new Error(`Error getting process ids for app '${appName}': ${err.message}`);
+    }
+    pids = [];
+  }
+  return pids;
+}
+
+async function killProcess (appName, force = false) {
+  let pids = await getProcessIds(appName);
+  if (pids.length === 0) {
+    // the process is not running
+    return;
+  }
+
+  try {
+    let args = force ? ['-9'] : [];
+    args.push('-x', appName);
+    await exec('pkill', args);
+  } catch (err) {
+    if (parseInt(err.code, 10) !== 1) {
+      throw new Error(`Error killing app '${appName}' with pkill: ${err.message}`);
+    }
+  }
+}
+
+export default { getProcessIds, killProcess };

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   ],
   "devDependencies": {
     "appium-gulp-plugins": "^1.3.11",
+    "asyncbox": "^2.3.1",
     "babel-eslint": "^6.1.0",
     "chai": "^3.0.0",
     "chai-as-promised": "^5.1.0",

--- a/test/process-specs.js
+++ b/test/process-specs.js
@@ -1,0 +1,93 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import * as teenProcess from 'teen_process';
+import sinon from 'sinon';
+import { process } from '../index.js';
+import { retryInterval } from 'asyncbox';
+
+
+chai.should();
+chai.use(chaiAsPromised);
+
+const SubProcess = teenProcess.SubProcess;
+
+describe('process', () => {
+  describe('getProcessIds', () => {
+    let proc;
+    before(async () => {
+      proc = new SubProcess('tail', ['-f', __filename]);
+      await proc.start();
+    });
+    after(async () => {
+      await proc.stop();
+    });
+    it('should get return an array for existing process', async () => {
+      let pids = await process.getProcessIds('tail');
+      pids.should.be.an.instanceof(Array);
+    });
+    it('should get process identifiers for existing process', async () => {
+      let pids = await process.getProcessIds('tail');
+      pids.should.have.length.at.least(1);
+    });
+    it('should get an empty array when the process does not exist', async () => {
+      let pids = await process.getProcessIds('sadfgasdfasdf');
+      pids.should.have.length(0);
+    });
+    it('should throw an error if pgrep fails', async () => {
+      let tpMock = sinon.mock(teenProcess);
+      tpMock.expects('exec').throws({message: 'Oops', code: 2});
+
+      await process.getProcessIds('tail').should.eventually.be.rejectedWith(/Oops/);
+
+      tpMock.restore();
+    });
+  });
+
+  describe('killProcess', async () => {
+    let proc;
+    beforeEach(async () => {
+      proc = new SubProcess('tail', ['-f', __filename]);
+      await proc.start();
+    });
+    afterEach(async () => {
+      if (proc.isRunning) {
+        await proc.stop();
+      }
+    });
+    it('should kill process that is running', async () => {
+      proc.isRunning.should.be.true;
+      await process.killProcess('tail');
+
+      // it may take a moment to actually be registered as killed
+      await retryInterval(10, 100, async () => {
+        proc.isRunning.should.be.false;
+      });
+    });
+    it('should do nothing if the process does not exist', async () => {
+      proc.isRunning.should.be.true;
+      await process.killProcess('asdfasdfasdf');
+
+      await retryInterval(10, 100, async () => {
+        proc.isRunning.should.be.false;
+      }).should.eventually.be.rejected;
+    });
+    it('should throw an error if pgrep fails', async () => {
+      let tpMock = sinon.mock(teenProcess);
+      tpMock.expects('exec').throws({message: 'Oops', code: 2});
+
+      await process.killProcess('tail').should.eventually.be.rejectedWith(/Oops/);
+
+      tpMock.restore();
+    });
+    it('should throw an error if pkill fails', async () => {
+      let tpMock = sinon.mock(teenProcess);
+      tpMock.expects('exec').twice()
+        .onFirstCall().returns({stdout: '42\n'})
+        .onSecondCall().throws({message: 'Oops', code: 2});
+
+      await process.killProcess('tail').should.eventually.be.rejectedWith(/Oops/);
+
+      tpMock.restore();
+    });
+  });
+});


### PR DESCRIPTION
In a few places we check for a process, and kill it. Consolidate it so that it is tested properly and available to whomever needs it.