### PR TITLE
Decrease maximum log records count to stabilise memory usage

### DIFF
--- a/lib/logging.js
+++ b/lib/logging.js
@@ -3,6 +3,7 @@ import npmlog from 'npmlog';
 
 // levels that are available from `npmlog`
 const NPM_LEVELS = ['silly', 'verbose', 'debug', 'info', 'http', 'warn', 'error'];
+const MAX_LOG_RECORDS_COUNT = 3000;
 
 // mock log object used in testing mode
 let mockLog = {};
@@ -31,6 +32,8 @@ function _getLogger () {
   } else {
     // otherwise, either use the global, or a new `npmlog` object
     logger = global._global_npmlog || npmlog;
+    // The default value is 10000, which causes excessive memory usage
+    logger.maxRecordSize = MAX_LOG_RECORDS_COUNT;
   }
   patchLogger(logger);
   return [logger, usingGlobalLog];


### PR DESCRIPTION
Reduce memory usage by limiting the size of internal log buffer.
![records](https://cloud.githubusercontent.com/assets/7767781/24713011/b82f17a2-1a24-11e7-98fc-2e9e2e20429c.png)
 