### PR TITLE
Fail zipping directory to which we have no access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 build
 coverage
 *.log
+.DS_Store

--- a/lib/zip.js
+++ b/lib/zip.js
@@ -13,8 +13,8 @@ const open = B.promisify(yauzl.open);
 
 /**
  * Extract zipfile to a directory
- * @param {string} zipFilepath 
- * @param {string} destDir 
+ * @param {string} zipFilepath
+ * @param {string} destDir
  */
 async function extractAllTo (zipFilepath, destDir) {
   return await extract(zipFilepath, {dir: destDir});
@@ -22,9 +22,9 @@ async function extractAllTo (zipFilepath, destDir) {
 
 /**
  * Extract a single zip entry to a directory
- * @param {Streamable} zipfile 
- * @param {Object} entry 
- * @param {str} destDir 
+ * @param {Streamable} zipfile
+ * @param {Object} entry
+ * @param {str} destDir
  */
 async function _extractEntryTo (zipfile, entry, destDir) {
 
@@ -32,7 +32,7 @@ async function _extractEntryTo (zipfile, entry, destDir) {
   await mkdirp(path.resolve(destDir, path.dirname(entry.fileName)));
 
   // Create a write stream
-  const writeStream = createWriteStream(path.resolve(destDir, entry.fileName), {flags: 'w'});  
+  const writeStream = createWriteStream(path.resolve(destDir, entry.fileName), {flags: 'w'});
   const writeStreamPromise = new B((resolve, reject) => {
     writeStream.once('finish', resolve);
     writeStream.once('error', reject);
@@ -58,7 +58,7 @@ async function _extractEntryTo (zipfile, entry, destDir) {
 
 /**
  * Get entries for a zip folder
- * @param {string} srcDir 
+ * @param {string} srcDir
  * @param {function} onEntry Callback when entry is read
  * @param {function} onError Callback when error occurs
  */
@@ -84,11 +84,13 @@ async function readEntries (zipFilepath, onEntry) {
 
 /**
  * Converts contents of local directory to an in-memory .zip buffer
- * @param {*} srcDir 
+ * @param {*} srcDir
  */
 async function toInMemoryZip (srcDir) {
-
-  // Create a writable stream that zip will be streamed to 
+  if (!await fs.hasAccess(srcDir)) {
+    throw new Error(`Unable to access directory '${srcDir}'`);
+  }
+  // Create a writable stream that zip will be streamed to
   const zipfilePath = path.resolve(await tempDir.openDir(), 'temp.zip');
   const zipWriteStream = createWriteStream(zipfilePath);
   const zipWriteStreamPromise = new B((resolve, reject) => {
@@ -98,9 +100,9 @@ async function toInMemoryZip (srcDir) {
 
   // Zip 'srcDir' and stream it to the above writable stream
   const archive = archiver('zip', {
-    zlib: {level: 9}    
+    zlib: {level: 9}
   });
-  archive.once('error', (err) => { throw new Error(err); });
+  archive.once('error', (err) => { throw err; }); // eslint-disable-line promise/prefer-await-to-callbacks
   archive.directory(srcDir, false);
   archive.pipe(zipWriteStream);
   archive.finalize();


### PR DESCRIPTION
My editor deletes trailing spaces, so there is some chaff in there. The essential part is `lib/zip.js`, lines 90-92. If the directory is not there, fail.

Otherwise the `appium-xcuitest-driver` [build fails catastrophically](https://travis-ci.org/appium/appium-xcuitest-driver/jobs/226870050#L5961-L5982) on [this test](https://github.com/appium/appium-xcuitest-driver/blob/master/test/functional/basic/file-movement-e2e-specs.js#L59-L61).

