### PR TITLE
Add a possibility to pass dynamic prefix generator to a logger instance

### DIFF
--- a/lib/logging.js
+++ b/lib/logging.js
@@ -1,4 +1,5 @@
 import npmlog from 'npmlog';
+import _ from 'lodash';
 
 
 // levels that are available from `npmlog`
@@ -54,7 +55,9 @@ function getLogger (prefix = null) {
   });
   // add all the levels from `npmlog`, and map to the underlying logger
   for (let level of NPM_LEVELS) {
-    wrappedLogger[level] = logger[level].bind(logger, prefix);
+    wrappedLogger[level] = (...args) => logger[level].call(logger,
+      _.isFunction(prefix) ? prefix() : prefix,
+      ...args);
   }
   // add method to log an error, and throw it, for convenience
   wrappedLogger.errorAndThrow = function (err) {

--- a/test/logger/logger-normal-specs.js
+++ b/test/logger/logger-normal-specs.js
@@ -3,6 +3,8 @@
 import { getDynamicLogger, restoreWriters, setupWriters,
          assertOutputContains, assertOutputDoesntContain } from './helpers';
 
+const LOG_LEVELS = ['silly', 'verbose', 'info', 'http', 'warn', 'error'];
+
 describe('normal logger', () => {
   let writers, log;
   beforeEach(() => {
@@ -15,29 +17,19 @@ describe('normal logger', () => {
     restoreWriters(writers);
   });
 
-  it('should not rewrite log levels outside of testing', () => {
-    log.silly('silly');
-    assertOutputContains(writers, 'silly');
-    log.verbose('verbose');
-    assertOutputContains(writers, 'verbose');
-    log.verbose('debug');
-    assertOutputContains(writers, 'debug');
-    log.info('info');
-    assertOutputContains(writers, 'info');
-    log.http('http');
-    assertOutputContains(writers, 'http');
-    log.warn('warn');
-    assertOutputContains(writers, 'warn');
-    log.error('error');
-    assertOutputContains(writers, 'error');
+  it('should not rewrite log levels outside of testing', function () {
+    for (const levelName of LOG_LEVELS) {
+      log[levelName](levelName);
+      assertOutputContains(writers, levelName);
+    }
   });
-  it('throw should not rewrite log levels outside of testing and throw error', () => {
+  it('throw should not rewrite log levels outside of testing and throw error', function () {
     (() => { log.errorAndThrow('msg1'); }).should.throw('msg1');
     (() => { log.errorAndThrow(new Error('msg2')); }).should.throw('msg2');
     assertOutputContains(writers, 'msg1');
     assertOutputContains(writers, 'msg2');
   });
-  it('should get and set log levels', () => {
+  it('should get and set log levels', function () {
     log.level = 'warn';
     log.level.should.equal('warn');
     log.info('information');
@@ -47,11 +39,13 @@ describe('normal logger', () => {
   });
 });
 
-describe('normal logger with prefix', () => {
+describe('normal logger with static prefix', () => {
   let writers, log;
+  const PREFIX = 'my_static_prefix';
+
   before(() => {
     writers = setupWriters();
-    log = getDynamicLogger(false, false, 'myprefix');
+    log = getDynamicLogger(false, false, PREFIX);
     log.level = 'silly';
   });
 
@@ -59,32 +53,44 @@ describe('normal logger with prefix', () => {
     restoreWriters(writers);
   });
 
-  it('should not rewrite log levels outside of testing', () => {
-    log.silly('silly');
-    assertOutputContains(writers, 'silly');
-    assertOutputContains(writers, 'myprefix');
-    log.verbose('verbose');
-    assertOutputContains(writers, 'verbose');
-    assertOutputContains(writers, 'myprefix');
-    log.verbose('debug');
-    assertOutputContains(writers, 'debug');
-    assertOutputContains(writers, 'myprefix');
-    log.info('info');
-    assertOutputContains(writers, 'info');
-    assertOutputContains(writers, 'myprefix');
-    log.http('http');
-    assertOutputContains(writers, 'http');
-    assertOutputContains(writers, 'myprefix');
-    log.warn('warn');
-    assertOutputContains(writers, 'warn');
-    assertOutputContains(writers, 'myprefix');
-    log.error('error');
-    assertOutputContains(writers, 'error');
-    assertOutputContains(writers, 'myprefix');
+  it('should not rewrite log levels outside of testing', function () {
+    for (const levelName of LOG_LEVELS) {
+      log[levelName](levelName);
+      assertOutputContains(writers, levelName);
+      assertOutputContains(writers, PREFIX);
+    }
   });
-  it('throw should not rewrite log levels outside of testing and throw error', () => {
+  it('throw should not rewrite log levels outside of testing and throw error', function () {
     (() => { log.errorAndThrow('msg'); }).should.throw('msg');
     assertOutputContains(writers, 'error');
-    assertOutputContains(writers, 'myprefix');
+    assertOutputContains(writers, PREFIX);
+  });
+});
+
+describe('normal logger with dynamic prefix', () => {
+  let writers, log;
+  const PREFIX = 'my_dynamic_prefix';
+
+  before(() => {
+    writers = setupWriters();
+    log = getDynamicLogger(false, false, () => PREFIX);
+    log.level = 'silly';
+  });
+
+  after(() => {
+    restoreWriters(writers);
+  });
+
+  it('should not rewrite log levels outside of testing', function () {
+    for (const levelName of LOG_LEVELS) {
+      log[levelName](levelName);
+      assertOutputContains(writers, levelName);
+      assertOutputContains(writers, PREFIX);
+    }
+  });
+  it('throw should not rewrite log levels outside of testing and throw error', function () {
+    (() => { log.errorAndThrow('msg'); }).should.throw('msg');
+    assertOutputContains(writers, 'error');
+    assertOutputContains(writers, PREFIX);
   });
 });


### PR DESCRIPTION
This will be needed to implement more advanced logging mechanism for parallel drivers. The idea is to create a single logger instance per driver instance and, as a log prefix, provide a special function, which adds session id if it exists for the current driver instance.

P. S. The whole idea might suck, so it would be pretty ok if this PR is closed :)