### PR TITLE
Add leak-proof truncate function

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -109,5 +109,13 @@ function unwrapElement (el) {
   return el;
 }
 
+/*
+ * Works the same way as _.truncate, but prevents memory leaks (see https://bugs.chromium.org/p/v8/issues/detail?id=2869) 
+ */
+function truncate (...args) {
+  // Hack that doesn't keep the whole string in memory
+  return ((' ') + _.truncate(...args)).substr(1);
+}
+
 export { hasValue, escapeSpace, escapeSpecialChars, localIp, cancellableDelay,
-         multiResolve, safeJsonParse, unwrapElement };
+         multiResolve, safeJsonParse, unwrapElement, truncate };

--- a/lib/util.js
+++ b/lib/util.js
@@ -110,7 +110,7 @@ function unwrapElement (el) {
 }
 
 /*
- * Works the same way as _.truncate, but prevents memory leaks (see https://bugs.chromium.org/p/v8/issues/detail?id=2869) 
+ * Works the same way as _.truncate, but prevents memory leaks (see https://bugs.chromium.org/p/v8/issues/detail?id=2869)
  */
 function truncate (...args) {
   // Hack that doesn't keep the whole string in memory

--- a/test/e2e/util-e2e-specs.js
+++ b/test/e2e/util-e2e-specs.js
@@ -1,0 +1,19 @@
+
+import { util } from '../..';
+import logger from '../../lib/logger';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+chai.use(chaiAsPromised);
+
+describe('util', function () {
+  describe('truncate', () => {
+    it('should not leak memory when concatenating 300 strings that are 30 mb each (but truncated to 1 character)', () => {
+      let s = [];
+      for (let i=0; i<1000; i++) {
+        logger.debug(`Adding 3mb string to string and concatenating to other string, truncated to 1 (expected string size ${i} mb)`);
+        let hugeString = Array(30000000).join('a');
+        s.push(`${util.truncate(hugeString, {length: 1000})}`);
+      }
+    });
+  });
+});

--- a/test/util-specs.js
+++ b/test/util-specs.js
@@ -209,4 +209,11 @@ describe('util', function () {
       util.unwrapElement(el).should.eql(4);
     });
   });
+
+  describe('truncate', () => {
+    it('should correctly call truncate', () => {
+      util.truncate('hello world').should.equal('hello world');
+      util.truncate('hello world', {length: 6}).should.equal('hel...');
+    });
+  });
 });


### PR DESCRIPTION
* Calls _.truncate but does a hack of adding (' ' + _.truncate(...args)).substr(1) that creates a new string instead of keeping it in memory
* This is due to a bug/feature in V8 (https://bugs.chromium.org/p/v8/issues/detail?id=2869)
* String.substr doesn't truncate the string, it keeps the whole string in memory
error: pathspec ' + _.truncate(...args)).substr(1) that creates a new string instead of keeping it in memory
* This is due to a bug/feature in V8 (https://bugs.chromium.org/p/v8/issues/detail?id=2869)
* String.substr doesnt' did not match any file(s) known to git