### PR TITLE
Workaround memory leak issue caused by truncated strings

### DIFF
--- a/lib/logging.js
+++ b/lib/logging.js
@@ -53,11 +53,14 @@ function getLogger (prefix = null) {
     enumerable: true,
     configurable: true
   });
+  // This lambda function is necessary to workaround unexpected memory leaks
+  // caused by NodeJS behavior described in https://bugs.chromium.org/p/v8/issues/detail?id=2869
+  const detachIfString = (x) => _.isString(x) ? (' ' + x).substr(1) : x;
   // add all the levels from `npmlog`, and map to the underlying logger
   for (let level of NPM_LEVELS) {
     wrappedLogger[level] = (...args) => logger[level].call(logger,
       _.isFunction(prefix) ? prefix() : prefix,
-      ...args);
+      ...(args.map(detachIfString)));
   }
   // add method to log an error, and throw it, for convenience
   wrappedLogger.errorAndThrow = function (err) {
@@ -66,7 +69,7 @@ function getLogger (prefix = null) {
       err = new Error(err);
     }
     // log and throw
-    this.error(err);
+    this.error(detachIfString(err));
     throw err;
   };
   if (!usingGlobalLog) {

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -55,7 +55,7 @@ function getLogger (prefix = null) {
   });
   // This lambda function is necessary to workaround unexpected memory leaks
   // caused by NodeJS behavior described in https://bugs.chromium.org/p/v8/issues/detail?id=2869
-  const detachIfString = (x) => _.isString(x) ? (' ' + x).substr(1) : x;
+  const detachIfString = (x) => _.isString(x) ? ` ${x}`.substr(1) : x;
   // add all the levels from `npmlog`, and map to the underlying logger
   for (let level of NPM_LEVELS) {
     wrappedLogger[level] = (...args) => logger[level].call(logger,

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -55,12 +55,12 @@ function getLogger (prefix = null) {
   });
   // This lambda function is necessary to workaround unexpected memory leaks
   // caused by NodeJS behavior described in https://bugs.chromium.org/p/v8/issues/detail?id=2869
-  const detachIfString = (x) => _.isString(x) ? ` ${x}`.substr(1) : x;
+  const unleakIfString = (x) => _.isString(x) ? ` ${x}`.substr(1) : x;
   // add all the levels from `npmlog`, and map to the underlying logger
   for (let level of NPM_LEVELS) {
     wrappedLogger[level] = (...args) => logger[level].call(logger,
       _.isFunction(prefix) ? prefix() : prefix,
-      ...(args.map(detachIfString)));
+      ...(args.map(unleakIfString)));
   }
   // add method to log an error, and throw it, for convenience
   wrappedLogger.errorAndThrow = function (err) {
@@ -69,7 +69,7 @@ function getLogger (prefix = null) {
       err = new Error(err);
     }
     // log and throw
-    this.error(detachIfString(err));
+    this.error(unleakIfString(err));
     throw err;
   };
   if (!usingGlobalLog) {


### PR DESCRIPTION
This should address memory leak issue caused by the fact that original strings are kept in memory after _.truncate operation is done on them. And since logs have an internal buffer of size 3000, where all logged strings are stored by by default, this might cause serious leaks in case some really big strings are being truncated and then passed to logs.