### PR TITLE
Fix protocol name comparsion

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -49,9 +49,9 @@ async function uploadFile (localPath, remotePath, uploadOptions = {}) {
   const {size} = await stat(localPath);
   log.info(`Uploading '${localPath}' of ${toReadableSizeString(size)} size to '${remotePath}'...`);
   const timeStarted = process.hrtime();
-  if (remoteUrl.protocol.startsWith('http')) {
+  if (['http:', 'https:'].includes(remoteUrl.protocol)) {
     await uploadFileToHttp(remoteUrl, uploadOptions);
-  } else if (remoteUrl.protocol === 'ftp') {
+  } else if (remoteUrl.protocol === 'ftp:') {
     await uploadFileToFtp(createReadStream(localPath), remoteUrl, uploadOptions);
   } else {
     throw new Error(`Cannot upload the file at '${localPath}' to '${remotePath}'. ` +


### PR DESCRIPTION
It looks like the parsed protocol name also includes a colon at the end