### PR TITLE
Update bluebird and make cancellable delay work

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -68,16 +68,24 @@ function localIp () {
  */
 function cancellableDelay (ms) {
   let timer;
-  return new B.Promise((resolve) => {
+  let resolve;
+  let reject;
+
+  const delay = new B.Promise((_resolve, _reject) => {
+    resolve = _resolve;
+    reject = _reject;
     timer = setTimeout(function () {
       resolve();
     }, ms);
-  })
-  .cancellable()
-  .catch(B.CancellationError, (err) => { // eslint-disable-line promise/prefer-await-to-callbacks
-    clearTimeout(timer);
-    throw err;
   });
+
+  // override Bluebird's `cancel`, which does not work when using `await` on
+  // a promise, since `resolve`/`reject` are never called
+  delay.cancel = function () {
+    clearTimeout(timer);
+    reject(new B.CancellationError());
+  };
+  return delay;
 }
 
 function multiResolve (roots, ...args) {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "archiver": "^1.3.0",
     "babel-runtime": "=5.8.24",
-    "bluebird": "^2.9.25",
+    "bluebird": "^3.5.1",
     "bplist-creator": "^0.0.7",
     "bplist-parser": "^0.1.0",
     "extract-zip": "^1.6.0",

--- a/test/util-specs.js
+++ b/test/util-specs.js
@@ -171,8 +171,9 @@ describe('util', function () {
     });
     it('cancel should work', async function () {
       let delay = util.cancellableDelay('1000');
-      B.delay(10).then(() => { delay.cancel(); }).done(); // eslint-disable-line
-      await delay.should.be.rejectedWith(/cancellation error/);
+      await B.delay(10);
+      delay.cancel();
+      await delay.should.eventually.be.rejectedWith(/cancellation error/);
     });
   });
 


### PR DESCRIPTION
In order to not have a mix of versions of `bluebird`, this package needs to be updated. Unfortunately `Promise.cancel` has been changed significantly (see http://bluebirdjs.com/docs/api/cancellation.html#cancellation). It used to abort the promise, where now it just makes it so `resolve` or `reject` are not called.

This PR just overrides the `cancel` function to do essentially what it did before.