### PR TITLE
reject image template matches below a threshold of default 0.5

### DIFF
--- a/lib/image-util.js
+++ b/lib/image-util.js
@@ -29,6 +29,7 @@ let cv = null;
 
 const BYTES_IN_PIXEL_BLOCK = 4;
 const SCANLINE_FILTER_METHOD = 4;
+const DEFAULT_MATCH_THRESHOLD = 0.5;
 
 const AVAILABLE_DETECTORS = [
   'AKAZE',
@@ -356,6 +357,8 @@ async function getImagesSimilarity (img1Data, img2Data, options = {}) {
  * @typedef {Object} OccurrenceOptions
  * @property {?boolean} visualize [false] Whether to return the resulting visalization
  * as an image (useful for debugging purposes)
+ * @property {?float} threshold [0.5] At what normalized threshold to reject
+ * a match
  */
 
 /**
@@ -381,7 +384,7 @@ async function getImagesSimilarity (img1Data, img2Data, options = {}) {
 async function getImageOccurrence (fullImgData, partialImgData, options = {}) {
   initOpenCV();
 
-  const {visualize = false} = options;
+  const {visualize = false, threshold = DEFAULT_MATCH_THRESHOLD} = options;
   const [fullImg, partialImg] = await B.all([
     cv.imdecodeAsync(fullImgData),
     cv.imdecodeAsync(partialImgData)
@@ -390,6 +393,11 @@ async function getImageOccurrence (fullImgData, partialImgData, options = {}) {
   try {
     const matched = await fullImg.matchTemplateAsync(partialImg, cv.TM_CCOEFF_NORMED);
     const minMax = await matched.minMaxLocAsync();
+    if (minMax.maxVal < threshold) {
+      throw new Error(`Cannot find any occurrences of the partial image in the full ` +
+                      `image above the threshold of ${threshold}. Highest match value ` +
+                      `found was ${minMax.maxVal}`);
+    }
     result.rect = {
       x: minMax.maxLoc.x,
       y: minMax.maxLoc.y,

--- a/test/image-util-specs.js
+++ b/test/image-util-specs.js
@@ -6,6 +6,7 @@ import { fs } from 'appium-support';
 import chaiAsPromised from 'chai-as-promised';
 
 chai.use(chaiAsPromised);
+chai.should();
 
 const FIXTURES_ROOT = path.resolve(__dirname, '..', '..', 'test', 'images');
 
@@ -115,6 +116,11 @@ describe('image-util', function () {
         rect.y.should.be.above(0);
         rect.width.should.be.above(0);
         rect.height.should.be.above(0);
+      });
+
+      it('should reject matches that fall below a threshold', async function () {
+        await getImageOccurrence(fullImage, partialImage, {threshold: 1.0})
+          .should.eventually.be.rejectedWith(/threshold/);
       });
 
       it('should visualize the partial image position in the full image', async function () {


### PR DESCRIPTION
my belief is that the primary use of this feature is to find things that exist on the screen, not to find the most likely place for them to exist (even when they don't).

to get the old behavior, just set threshold to 0