### PR TITLE
Only load mjpeg-consumer package at runtime

### DIFF
--- a/lib/mjpeg.js
+++ b/lib/mjpeg.js
@@ -43,6 +43,9 @@ class MJpegStream extends Writable {
    */
   constructor (mJpegUrl, errorHandler = _.noop, options = {}) {
     super(options);
+
+    initMJpegConsumer();
+
     this.errorHandler = errorHandler;
     this.url = mJpegUrl;
     this.clear();
@@ -101,8 +104,6 @@ class MJpegStream extends Writable {
    * Start reading the MJpeg stream and storing the last image
    */
   async start (serverTimeout = MJPEG_SERVER_TIMEOUT_MS) {
-    initMJpegConsumer();
-
     // ensure we're not started already
     this.stop();
 

--- a/lib/mjpeg.js
+++ b/lib/mjpeg.js
@@ -4,9 +4,27 @@ import log from './logger';
 import http from 'http';
 import B from 'bluebird';
 import { getJimpImage, MIME_PNG } from './image-util';
-import MJpegConsumer from 'mjpeg-consumer';
 import mJpegServer from 'mjpeg-server';
 import { Writable } from 'stream';
+
+
+// lazy load this, as it might not be available
+let MJpegConsumer = null;
+
+/**
+ * @throws {Error} If `mjpeg-consumer` module is not installed or cannot be loaded
+ */
+function initMJpegConsumer () {
+  if (!MJpegConsumer) {
+    try {
+      MJpegConsumer = require('mjpeg-consumer');
+    } catch (ign) {}
+  }
+  if (!MJpegConsumer) {
+    throw new Error('mjpeg-consumer module is required to use MJPEG-over-HTTP features. ' +
+                    'Please install it first (npm i -g mjpeg-consumer) and restart Appium.');
+  }
+}
 
 const TEST_IMG_JPG = '/9j/4QAYRXhpZgAASUkqAAgAAAAAAAAAAAAAAP/sABFEdWNreQABAAQAAAAeAAD/4QOBaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wLwA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/PiA8eDp4bXBtZXRhIHhtbG5zOng9ImFkb2JlOm5zOm1ldGEvIiB4OnhtcHRrPSJBZG9iZSBYTVAgQ29yZSA1LjYtYzE0MCA3OS4xNjA0NTEsIDIwMTcvMDUvMDYtMDE6MDg6MjEgICAgICAgICI+IDxyZGY6UkRGIHhtbG5zOnJkZj0iaHR0cDovL3d3dy53My5vcmcvMTk5OS8wMi8yMi1yZGYtc3ludGF4LW5zIyI+IDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIiB4bWxuczpzdFJlZj0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3NUeXBlL1Jlc291cmNlUmVmIyIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bXBNTTpPcmlnaW5hbERvY3VtZW50SUQ9InhtcC5kaWQ6NGY5ODc1OTctZGE2My00Y2M0LTkzNDMtNGYyNjgzMGUwNjk3IiB4bXBNTTpEb2N1bWVudElEPSJ4bXAuZGlkOjlDMzI3QkY0N0Q3NTExRThCMTlDOTVDMDc2RDE5MDY5IiB4bXBNTTpJbnN0YW5jZUlEPSJ4bXAuaWlkOjlDMzI3QkYzN0Q3NTExRThCMTlDOTVDMDc2RDE5MDY5IiB4bXA6Q3JlYXRvclRvb2w9IkFkb2JlIFBob3Rvc2hvcCBDQyAyMDE4IChNYWNpbnRvc2gpIj4gPHhtcE1NOkRlcml2ZWRGcm9tIHN0UmVmOmluc3RhbmNlSUQ9InhtcC5paWQ6NGY5ODc1OTctZGE2My00Y2M0LTkzNDMtNGYyNjgzMGUwNjk3IiBzdFJlZjpkb2N1bWVudElEPSJ4bXAuZGlkOjRmOTg3NTk3LWRhNjMtNGNjNC05MzQzLTRmMjY4MzBlMDY5NyIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/Pv/uAA5BZG9iZQBkwAAAAAH/2wCEABALCwsMCxAMDBAXDw0PFxsUEBAUGx8XFxcXFx8eFxoaGhoXHh4jJSclIx4vLzMzLy9AQEBAQEBAQEBAQEBAQEABEQ8PERMRFRISFRQRFBEUGhQWFhQaJhoaHBoaJjAjHh4eHiMwKy4nJycuKzU1MDA1NUBAP0BAQEBAQEBAQEBAQP/AABEIACAAIAMBIgACEQEDEQH/xABgAAEAAwEAAAAAAAAAAAAAAAAABAUHCAEBAAAAAAAAAAAAAAAAAAAAABAAAQMCAgsAAAAAAAAAAAAAAAECBBEDEgYhMRODo7PTVAUWNhEBAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEQMRAD8Az8AAdAAAAAAI8+fE8dEuTZtzZR7VMb6OdTE5GJoYirrUp/e8qd9wb3TGe/lJ2551sx8D/9k=';
 
@@ -83,6 +101,8 @@ class MJpegStream extends Writable {
    * Start reading the MJpeg stream and storing the last image
    */
   async start (serverTimeout = MJPEG_SERVER_TIMEOUT_MS) {
+    initMJpegConsumer();
+
     // ensure we're not started already
     this.stop();
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "yauzl": "^2.7.0"
   },
   "scripts": {
+    "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",
     "prepublish": "gulp prepublish",
     "test": "gulp once",
     "watch": "gulp watch",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "jsftp": "^2.1.2",
     "lodash": "^4.2.1",
     "md5-file": "^4.0.0",
-    "mjpeg-consumer": "^1.1.0",
     "mjpeg-server": "^0.3.0",
     "mkdirp": "^0.5.1",
     "mv": "^2.1.1",


### PR DESCRIPTION
Rather than insisting that everyone install `mjpeg-consumer`, which has a dependency on `buffertools` which gets built natively, lazily load the package when it is needed, insisting that users who want this feature install the package themselves.

Without this it becomes impossible to do things like bundle Appium and run on a different system, upgrade Node without reinstalling altogether, etc.