### PR TITLE
Do not check the list of supported versions

### DIFF
--- a/lib/system.js
+++ b/lib/system.js
@@ -1,8 +1,7 @@
 import { exec } from 'teen_process';
 import os from 'os';
 
-
-const SUPPORTED_OSX_VERSIONS = ['10.8', '10.9', '10.10', '10.11', '10.12', '10.13'];
+const VERSION_PATTERN = /^(\d+\.\d+)/m;
 
 function isWindows () {
   return os.type() === 'Windows_NT';
@@ -38,12 +37,11 @@ async function macOsxVersion () {
     throw new Error(`Could not detect Mac OS X Version: ${err}`);
   }
 
-  const ver = SUPPORTED_OSX_VERSIONS.find((v) => stdout.startsWith(v));
-  if (!ver) {
+  const versionMatch = VERSION_PATTERN.exec(stdout);
+  if (!versionMatch) {
     throw new Error(`Could not detect Mac OS X Version from sw_vers output: '${stdout}'`);
   }
-
-  return ver;
+  return versionMatch[1];
 }
 
 export { isWindows, isMac, isLinux, isOSWin64, arch, macOsxVersion };

--- a/test/system-specs.js
+++ b/test/system-specs.js
@@ -62,9 +62,9 @@ describe('system', function () {
     });
 
     it("should throw an error if OSX version can't be determined", async function () {
-      let invalidOsx = '99.99.99';
+      let invalidOsx = 'error getting operation system version blabla';
       tpMock.expects('exec').once().withExactArgs('sw_vers', ['-productVersion']).returns({stdout: invalidOsx});
-      await system.macOsxVersion().should.eventually.be.rejectedWith(invalidOsx);
+      await system.macOsxVersion().should.eventually.be.rejectedWith(new RegExp(_.escapeRegExp(invalidOsx)));
     });
   });
 


### PR DESCRIPTION
Addresses https://github.com/appium/appium/issues/11422

I would assume such verification should not be located in the library, but in the client code instead (appium-doctor in such case if it is necessary at all).