### PR TITLE
Update appium-gulp-plugins

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-node_modules
-*.log
-test
-coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "6"
   - "8"
+  - "10"
 sudo: false
 addons:
   apt:

--- a/index.js
+++ b/index.js
@@ -12,7 +12,12 @@ import * as zip from './lib/zip';
 import * as imageUtil from './lib/image-util';
 import * as mjpeg from './lib/mjpeg';
 
-// can't add to other exports `as default`
-// until JSHint figures out how to parse that pattern
-export default { tempDir, system, util, fs, cancellableDelay, plist, mkdirp,
-                 logger, process, zip, imageUtil, net, mjpeg };
+
+export {
+  tempDir, system, util, fs, cancellableDelay, plist, mkdirp, logger, process,
+  zip, imageUtil, net, mjpeg,
+};
+export default {
+  tempDir, system, util, fs, cancellableDelay, plist, mkdirp, logger, process,
+  zip, imageUtil, net, mjpeg,
+};

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -41,9 +41,10 @@ let fs = {
   glob: B.promisify(glob)
 };
 
-const simples = ['open', 'close', 'access', 'readFile', 'writeFile',
-                 'write', 'read', 'readlink', 'chmod', 'unlink', 'readdir',
-                 'stat', 'rename', 'lstat'];
+const simples = [
+  'open', 'close', 'access', 'readFile', 'writeFile', 'write', 'read',
+  'readlink', 'chmod', 'unlink', 'readdir', 'stat', 'rename', 'lstat',
+];
 
 for (let s of simples) {
   fs[s] = B.promisify(_fs[s]);

--- a/lib/image-util.js
+++ b/lib/image-util.js
@@ -22,7 +22,7 @@ let cv = null;
  * @property {number} y - The y coordinate
  */
 
- /**
+/**
  * @typedef {Object} Rect
  * @property {number} x - The top left coordinate
  * @property {number} y - The bottom right coordinate
@@ -471,7 +471,7 @@ async function cropBase64Image (base64Image, rect) {
  */
 async function base64ToImage (base64Image) {
   const imageBuffer = Buffer.from(base64Image, 'base64');
-  return new B((resolve, reject) => {
+  return await new B((resolve, reject) => {
     const image = new PNG({filterType: SCANLINE_FILTER_METHOD});
     image.parse(imageBuffer, (err, image) => { // eslint-disable-line promise/prefer-await-to-callbacks
       if (err) {
@@ -489,7 +489,7 @@ async function base64ToImage (base64Image) {
  * @return {string} The string with base64 encoded image
  */
 async function imageToBase64 (image) {
-  return new B((resolve, reject) => {
+  return await new B((resolve, reject) => {
     const chunks = [];
     image.pack()
     .on('data', (chunk) => chunks.push(chunk)).on('end', () => {
@@ -544,6 +544,8 @@ function getRectIntersection (rect, imageSize) {
   return {left, top, width, height};
 }
 
-export { cropBase64Image, base64ToImage, imageToBase64, cropImage,
-         getImagesMatches, getImagesSimilarity, getImageOccurrence,
-         getJimpImage, MIME_JPEG, MIME_PNG, MIME_BMP };
+export {
+  cropBase64Image, base64ToImage, imageToBase64, cropImage, getImagesMatches,
+  getImagesSimilarity, getImageOccurrence, getJimpImage, MIME_JPEG, MIME_PNG,
+  MIME_BMP,
+};

--- a/lib/mjpeg.js
+++ b/lib/mjpeg.js
@@ -131,9 +131,9 @@ class MJpegStream extends Writable {
     this.request = request(this.url);
 
     this.request
-      .on('error', onErr)   // ensure we do something with errors
-      .pipe(this.consumer)  // allow chunking and transforming of jpeg data
-      .pipe(this);          // send the actual jpegs to ourself
+      .on('error', onErr) // ensure we do something with errors
+      .pipe(this.consumer) // allow chunking and transforming of jpeg data
+      .pipe(this); // send the actual jpegs to ourself
 
     await startPromise;
   }

--- a/lib/process.js
+++ b/lib/process.js
@@ -41,4 +41,4 @@ async function killProcess (appName, force = false) {
   }
 }
 
-export default { getProcessIds, killProcess };
+export { getProcessIds, killProcess };

--- a/lib/tempdir.js
+++ b/lib/tempdir.js
@@ -10,11 +10,13 @@ const RDWR_EXCL = cnst.O_CREAT | cnst.O_TRUNC | cnst.O_RDWR | cnst.O_EXCL;
 async function tempDir () {
   let now = new Date();
   let filePath = nodePath.join(os.tmpdir(),
-    [now.getFullYear(), now.getMonth(), now.getDate(),
-    '-',
-    process.pid,
-    '-',
-    (Math.random() * 0x100000000 + 1).toString(36)].join(''));
+    [
+      now.getFullYear(), now.getMonth(), now.getDate(),
+      '-',
+      process.pid,
+      '-',
+      (Math.random() * 0x100000000 + 1).toString(36),
+    ].join(''));
   // creates a temp directory using the date and a random string
 
   await fs.mkdir(filePath);
@@ -63,7 +65,7 @@ function parseAffixes (rawAffixes, defaultPrefix) {
 const _static = tempDir();
 const openDir = tempDir;
 
-async function staticDir () {
+async function staticDir () { // eslint-disable-line require-await
   return _static;
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -33,15 +33,15 @@ function escapeSpecialChars (str, quoteEscape) {
     quoteEscape = false;
   }
   str = str
-        .replace(/[\\]/g, '\\\\')
-        .replace(/[\/]/g, '\\/')
-        .replace(/[\b]/g, '\\b')
-        .replace(/[\f]/g, '\\f')
-        .replace(/[\n]/g, '\\n')
-        .replace(/[\r]/g, '\\r')
-        .replace(/[\t]/g, '\\t')
-        .replace(/[\"]/g, '\\"')
-        .replace(/\\'/g, "\\'");
+    .replace(/[\\]/g, '\\\\')
+    .replace(/[\/]/g, '\\/') // eslint-disable-line no-useless-escape
+    .replace(/[\b]/g, '\\b')
+    .replace(/[\f]/g, '\\f')
+    .replace(/[\n]/g, '\\n')
+    .replace(/[\r]/g, '\\r')
+    .replace(/[\t]/g, '\\t')
+    .replace(/[\"]/g, '\\"') // eslint-disable-line no-useless-escape
+    .replace(/\\'/g, "\\'");
   if (quoteEscape) {
     let re = new RegExp(quoteEscape, "g");
     str = str.replace(re, `\\${quoteEscape}`);
@@ -167,6 +167,8 @@ function toReadableSizeString (bytes) {
   return `${intBytes} B`;
 }
 
-export { hasValue, escapeSpace, escapeSpecialChars, localIp, cancellableDelay,
-         multiResolve, safeJsonParse, unwrapElement, filterObject,
-         toReadableSizeString };
+export {
+  hasValue, escapeSpace, escapeSpecialChars, localIp, cancellableDelay,
+  multiResolve, safeJsonParse, unwrapElement, filterObject,
+  toReadableSizeString,
+};

--- a/package.json
+++ b/package.json
@@ -22,15 +22,21 @@
   "directories": {
     "lib": "lib"
   },
+  "files": [
+    "index.js",
+    "lib",
+    "build/index.js",
+    "build/lib"
+  ],
   "dependencies": {
+    "@babel/runtime": "^7.0.0",
     "archiver": "^1.3.0",
-    "babel-runtime": "=5.8.24",
     "bluebird": "^3.5.1",
     "bplist-creator": "^0.0.7",
     "bplist-parser": "^0.1.0",
     "extract-zip": "^1.6.0",
     "glob": "^7.1.2",
-    "jimp": "^0.2.28",
+    "jimp": "^0.5.3",
     "jsftp": "^2.1.2",
     "lodash": "^4.2.1",
     "md5-file": "^4.0.0",
@@ -51,7 +57,7 @@
   },
   "scripts": {
     "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",
-    "prepublish": "gulp prepublish",
+    "prepare": "gulp prepublish",
     "test": "gulp once",
     "watch": "gulp watch",
     "mocha": "mocha",
@@ -68,18 +74,18 @@
     "precommit-test"
   ],
   "devDependencies": {
-    "appium-gulp-plugins": "^2.2.0",
+    "ajv": "^6.5.3",
+    "appium-gulp-plugins": "^3.1.0",
     "asyncbox": "^2.3.1",
-    "babel-eslint": "^7.1.1",
+    "babel-eslint": "^10.0.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^3.10.2",
-    "eslint-config-appium": "^2.1.0",
-    "eslint-plugin-babel": "^3.3.0",
+    "eslint": "^5.2.0",
+    "eslint-config-appium": "^3.1.0",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-mocha": "^4.7.0",
-    "eslint-plugin-promise": "^3.3.1",
-    "gulp": "^3.9.0",
+    "eslint-plugin-mocha": "^5.0.0",
+    "eslint-plugin-promise": "^4.0.0",
+    "gulp": "^4.0.0",
     "mocha": "^5.1.1",
     "mock-fs": "^4.2.0",
     "pre-commit": "^1.1.3",
@@ -87,16 +93,7 @@
   },
   "greenkeeper": {
     "ignore": [
-      "archiver",
-      "babel-eslint",
-      "babel-preset-env",
-      "eslint",
-      "eslint-plugin-babel",
-      "eslint-plugin-import",
-      "eslint-plugin-mocha",
-      "eslint-plugin-promise",
-      "gulp",
-      "babel-runtime"
+      "archiver"
     ]
   }
 }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,21 +1,13 @@
 import { EventEmitter } from 'events';
 
 class MockReadWriteStream extends EventEmitter {
-  resume () {
+  resume () {}
 
-  }
+  pause () {}
 
-  pause () {
+  setEncoding () {}
 
-  }
-
-  setEncoding () {
-
-  }
-
-  flush () {
-
-  }
+  flush () {}
 
   write (msg) {
     this.emit('data', msg);

--- a/test/image-util-e2e-specs.js
+++ b/test/image-util-e2e-specs.js
@@ -4,7 +4,7 @@ import { base64ToImage, imageToBase64, cropImage,
 import path from 'path';
 import _ from 'lodash';
 import chai from 'chai';
-import { fs } from 'appium-support';
+import { fs } from '..';
 import chaiAsPromised from 'chai-as-promised';
 
 chai.use(chaiAsPromised);

--- a/test/logger/helpers.js
+++ b/test/logger/helpers.js
@@ -11,7 +11,7 @@ function setupWriters () {
           'stderr': sinon.spy(process.stderr, 'write')};
 }
 
-function getDynamicLogger (testingMode, forceLogs, prefix=null) {
+function getDynamicLogger (testingMode, forceLogs, prefix = null) {
   process.env._TESTING = testingMode ? '1' : '0';
   process.env._FORCE_LOGS = forceLogs ? '1' : '0';
   return logger.getLogger(prefix);
@@ -50,5 +50,7 @@ function assertOutputDoesntContain (writers, output) {
   }
 }
 
-export { setupWriters, restoreWriters, assertOutputContains,
-         assertOutputDoesntContain, getDynamicLogger };
+export {
+  setupWriters, restoreWriters, assertOutputContains, assertOutputDoesntContain,
+  getDynamicLogger,
+};

--- a/test/mjpeg-e2e-specs.js
+++ b/test/mjpeg-e2e-specs.js
@@ -40,7 +40,7 @@ describe('MJpeg Stream (e2e)', function () {
     const endBytes = Buffer.from([0xff, 0xd9]);
     const startPos = stream.lastChunk.indexOf(startBytes);
     const endPos = stream.lastChunk.indexOf(endBytes);
-    startPos.should.eql(0);   // proves we have a jpeg
+    startPos.should.eql(0); // proves we have a jpeg
     endPos.should.eql(1278); // proves we have a jpeg of the right size
 
     // verify we can get the base64 version too

--- a/test/process-specs.js
+++ b/test/process-specs.js
@@ -43,7 +43,7 @@ describe('process', function () {
     });
   });
 
-  describe('killProcess', async function () {
+  describe('killProcess', function () {
     let proc;
     beforeEach(async function () {
       proc = new SubProcess('tail', ['-f', __filename]);
@@ -59,7 +59,7 @@ describe('process', function () {
       await process.killProcess('tail');
 
       // it may take a moment to actually be registered as killed
-      await retryInterval(10, 100, async () => {
+      await retryInterval(10, 100, async () => { // eslint-disable-line require-await
         proc.isRunning.should.be.false;
       });
     });
@@ -67,7 +67,7 @@ describe('process', function () {
       proc.isRunning.should.be.true;
       await process.killProcess('asdfasdfasdf');
 
-      await retryInterval(10, 100, async () => {
+      await retryInterval(10, 100, async () => { // eslint-disable-line require-await
         proc.isRunning.should.be.false;
       }).should.eventually.be.rejected;
     });

--- a/test/util-specs.js
+++ b/test/util-specs.js
@@ -119,42 +119,60 @@ describe('util', function () {
     it('should find a local ip address', function () {
       let ifConfigOut = {
         lo0:
-         [{ address: '::1',
-            netmask: 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
-            family: 'IPv6',
-            mac: '00:00:00:00:00:00',
-            scopeid: 0,
-            internal: true },
-          { address: '127.0.0.1',
-            netmask: '255.0.0.0',
-            family: 'IPv4',
-            mac: '00:00:00:00:00:00',
-            internal: true },
-          { address: 'fe80::1',
-            netmask: 'ffff:ffff:ffff:ffff::',
-            family: 'IPv6',
-            mac: '00:00:00:00:00:00',
-            scopeid: 1,
-            internal: true }],
+          [
+            {
+              address: '::1',
+              netmask: 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+              family: 'IPv6',
+              mac: '00:00:00:00:00:00',
+              scopeid: 0,
+              internal: true,
+            },
+            {
+              address: '127.0.0.1',
+              netmask: '255.0.0.0',
+              family: 'IPv4',
+              mac: '00:00:00:00:00:00',
+              internal: true,
+            },
+            {
+              address: 'fe80::1',
+              netmask: 'ffff:ffff:ffff:ffff::',
+              family: 'IPv6',
+              mac: '00:00:00:00:00:00',
+              scopeid: 1,
+              internal: true,
+            }
+          ],
         en0:
-         [{ address: 'xxx',
-            netmask: 'ffff:ffff:ffff:ffff::',
-            family: 'IPv6',
-            mac: 'd0:e1:40:93:56:9a',
-            scopeid: 4,
-            internal: false },
-          { address: '123.123.123.123',
-            netmask: '255.255.254.0',
-            family: 'IPv4',
-            mac: 'xxx',
-            internal: false }],
+          [
+            {
+              address: 'xxx',
+              netmask: 'ffff:ffff:ffff:ffff::',
+              family: 'IPv6',
+              mac: 'd0:e1:40:93:56:9a',
+              scopeid: 4,
+              internal: false,
+            },
+            {
+              address: '123.123.123.123',
+              netmask: '255.255.254.0',
+              family: 'IPv4',
+              mac: 'xxx',
+              internal: false,
+            }
+          ],
         awdl0:
-         [{ address: 'xxx',
-            netmask: 'ffff:ffff:ffff:ffff::',
-            family: 'IPv6',
-            mac: 'xxx',
-            scopeid: 7,
-            internal: false }]
+          [
+            {
+              address: 'xxx',
+              netmask: 'ffff:ffff:ffff:ffff::',
+              family: 'IPv6',
+              mac: 'xxx',
+              scopeid: 7,
+              internal: false,
+            }
+          ],
       };
       let osMock = sinon.mock(os);
       osMock.expects('networkInterfaces').returns(ifConfigOut);

--- a/test/zip-specs.js
+++ b/test/zip-specs.js
@@ -67,7 +67,7 @@ describe('#zip', function () {
 
     it('should stop iterating zipFile if onEntry callback returns false', async function () {
       let i = 0;
-      await zip.readEntries(zippedFilepath, async () => {
+      await zip.readEntries(zippedFilepath, async () => { // eslint-disable-line require-await
         i++;
         return false;
       });


### PR DESCRIPTION
This PR does two main things:
1. Updates `eslint-config-appium` and fixes any linting errors.
1. Updated `appium-gulp-plugins` and moves to Babel 7 and Gulp 4.

See https://github.com/appium/appium-gulp-plugins/pull/35 for more details.