### PR TITLE
Unwrap w3c elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,9 +18,9 @@ const { mkdirp } = mkdirpIndex;
 
 export {
   tempDir, system, util, fs, cancellableDelay, plist, mkdirp, logger, process,
-  zip, imageUtil, net, mjpeg,
+  zip, imageUtil, net, mjpeg
 };
 export default {
   tempDir, system, util, fs, cancellableDelay, plist, mkdirp, logger, process,
-  zip, imageUtil, net, mjpeg,
+  zip, imageUtil, net, mjpeg
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -113,7 +113,7 @@ function safeJsonParse (obj) {
  *   { ELEMENT: 4 } becomes 4
  */
 function unwrapElement (el) {
-  if (_.isObject(el)) {
+  if (_.isPlainObject(el)) {
     if (el[W3C_WEB_ELEMENT_IDENTIFIER]) {
       return el[W3C_WEB_ELEMENT_IDENTIFIER];
     } else if (el.ELEMENT) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -116,9 +116,9 @@ function unwrapElement (el) {
   if (_.isPlainObject(el)) {
     if (el[W3C_WEB_ELEMENT_IDENTIFIER]) {
       return el[W3C_WEB_ELEMENT_IDENTIFIER];
-    } else if (el.ELEMENT) {
-      return el.ELEMENT;
     }
+
+    return el.ELEMENT;
   }
   return el;
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -111,14 +111,13 @@ function safeJsonParse (obj) {
 /*
  * Removes the wrapper from element, if it exists.
  *   { ELEMENT: 4 } becomes 4
+ *   { element-6066-11e4-a52e-4f735466cecf: 5 } becomes 5
  */
 function unwrapElement (el) {
-  if (_.isPlainObject(el)) {
-    if (el[W3C_WEB_ELEMENT_IDENTIFIER]) {
-      return el[W3C_WEB_ELEMENT_IDENTIFIER];
+  for (const propName of [W3C_WEB_ELEMENT_IDENTIFIER, 'ELEMENT']) {
+    if (_.has(el, propName)) {
+      return el[propName];
     }
-
-    return el.ELEMENT;
   }
   return el;
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -3,6 +3,8 @@ import _ from 'lodash';
 import os from 'os';
 import path from 'path';
 
+const W3C_WEB_ELEMENT_IDENTIFIER = 'element-6066-11e4-a52e-4f735466cecf';
+
 export function hasContent (val) {
   return _.isString(val) && val !== "";
 }
@@ -111,8 +113,12 @@ function safeJsonParse (obj) {
  *   { ELEMENT: 4 } becomes 4
  */
 function unwrapElement (el) {
-  if (typeof el === 'object' && el.ELEMENT) {
-    return el.ELEMENT;
+  if (_.isObject(el)) {
+    if (el[W3C_WEB_ELEMENT_IDENTIFIER]) {
+      return el[W3C_WEB_ELEMENT_IDENTIFIER];
+    } else if (el.ELEMENT) {
+      return el.ELEMENT;
+    }
   }
   return el;
 }
@@ -192,5 +198,5 @@ function isSubPath (originalPath, root, forcePosix = null) {
 export {
   hasValue, escapeSpace, escapeSpecialChars, localIp, cancellableDelay,
   multiResolve, safeJsonParse, unwrapElement, filterObject,
-  toReadableSizeString, isSubPath,
+  toReadableSizeString, isSubPath, W3C_WEB_ELEMENT_IDENTIFIER
 };

--- a/test/util-specs.js
+++ b/test/util-specs.js
@@ -6,6 +6,8 @@ import B from 'bluebird';
 import sinon from 'sinon';
 import os from 'os';
 
+const {W3C_WEB_ELEMENT_IDENTIFIER} = util;
+
 
 const should = chai.should();
 chai.use(chaiAsPromised);
@@ -226,6 +228,19 @@ describe('util', function () {
     it('should unwrap a wrapped element', function () {
       let el = {ELEMENT: 4};
       util.unwrapElement(el).should.eql(4);
+    });
+    it('should unwrap a wrapped element that uses W3C element identifier', function () {
+      let el = {
+        [W3C_WEB_ELEMENT_IDENTIFIER]: 5
+      };
+      util.unwrapElement(el).should.eql(5);
+    });
+    it('should unwrap a wrapped element and prioritize W3C element identifier', function () {
+      let el = {
+        ELEMENT: 7,
+        [W3C_WEB_ELEMENT_IDENTIFIER]: 6,
+      };
+      util.unwrapElement(el).should.eql(6);
     });
   });
 


### PR DESCRIPTION
* `unwrapElement` should work for both [W3C elements](https://www.w3.org/TR/webdriver1/#elements) (`{"element-6066-11e4-a52e-4f735466cecf": "<ELEMENT-UUID>"}`) and JSONWP elements (`{"ELEMENT": "<ELEMENT-UUID>"}`)
* It prioritizes the W3C uuid when both are provided:
* e.g.)

```
{
  "ELEMENT": 1,
  "element-6066-11e4-a52e-4f735466cecf": 2 
}
```

will be unwrapped as 2.