### PR TITLE
Fix the constant in hasAccess method

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -15,7 +15,7 @@ const md5 = B.promisify(md5file);
 let fs = {
   async hasAccess (path) {
     try {
-      await this.access(path, fs.F_OK | fs.R_OK);
+      await this.access(path, _fs.R_OK);
     } catch (err) {
       return false;
     }


### PR DESCRIPTION
The `fs` object here does not contain the necessary constants, so they all are equal to `undefined`. The constants should be imported from the system module instead or copied to our wrapper explicitly.