### PR TITLE
Require from global if opencv4nodejs is not found locally

### DIFF
--- a/lib/image-util.js
+++ b/lib/image-util.js
@@ -4,6 +4,10 @@ import { Buffer } from 'buffer';
 import { PNG } from 'pngjs';
 import B from 'bluebird';
 import { hasValue } from './util';
+import { exec } from 'teen_process';
+import path from 'path';
+import fs from './fs';
+
 
 const { MIME_JPEG, MIME_PNG, MIME_BMP } = Jimp;
 let cv = null;
@@ -88,17 +92,43 @@ async function getJimpImage (data) {
 }
 
 /**
+ * Utility function to extend node functionality, allowing us to require
+ * modules that are installed globally
+ *
+ * @param {string} packageName - the name of the package to be required
+ */
+async function requirePackage (packageName) {
+  // see if we can get it locally
+  try {
+    return require(packageName);
+  } catch (ign) {}
+
+  // find the npm global root
+  const {stdout} = await exec('npm', ['root', '-g']);
+  const globalNPMRoot = stdout.trim();
+
+  // get the global package root
+  const packageDir = path.join(globalNPMRoot, packageName);
+  if (!await fs.exists(packageDir)) {
+    // not installed
+    throw new Error(`Unable to find global '${packageName}' module`);
+  }
+
+  return require(packageDir);
+}
+
+/**
  * @throws {Error} If opencv4nodejs module is not installed or cannot be loaded
  */
-function initOpenCV () {
+async function initOpenCV () {
   if (!cv) {
     try {
-      cv = require('opencv4nodejs');
+      cv = await requirePackage('opencv4nodejs');
     } catch (ign) {}
   }
   if (!cv) {
-    throw new Error('opencv4nodejs module is required to use OpenCV features. ' +
-                    'Please install it first (npm i -g opencv4nodejs) and restart Appium. ' +
+    throw new Error(`'opencv4nodejs' module is required to use OpenCV features. ` +
+                    `Please install it first ('npm i -g opencv4nodejs') and restart Appium. ` +
                     'Read https://github.com/justadudewhohacks/opencv4nodejs#how-to-install for more details on this topic.');
   }
 }
@@ -235,7 +265,7 @@ function highlightRegion (mat, region) {
  * @throws {Error} If `detectorName` value is unknown.
  */
 async function getImagesMatches (img1Data, img2Data, options = {}) {
-  initOpenCV();
+  await initOpenCV();
 
   const {detectorName = 'ORB', visualize = false,
          goodMatchesFactor, matchFunc = 'BruteForce'} = options;
@@ -335,7 +365,7 @@ async function getImagesMatches (img1Data, img2Data, options = {}) {
  * @throws {Error} If the given images have different resolution.
  */
 async function getImagesSimilarity (img1Data, img2Data, options = {}) {
-  initOpenCV();
+  await initOpenCV();
 
   const {visualize = false} = options;
   let [template, reference] = await B.all([
@@ -417,7 +447,7 @@ async function getImagesSimilarity (img1Data, img2Data, options = {}) {
  * @throws {Error} If no occurences of the partial image can be found in the full image
  */
 async function getImageOccurrence (fullImgData, partialImgData, options = {}) {
-  initOpenCV();
+  await initOpenCV();
 
   const {visualize = false, threshold = DEFAULT_MATCH_THRESHOLD} = options;
   const [fullImg, partialImg] = await B.all([

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -53,6 +53,7 @@ function getLogger (prefix = null) {
     enumerable: true,
     configurable: true
   });
+
   // This lambda function is necessary to workaround unexpected memory leaks
   // caused by NodeJS behavior described in https://bugs.chromium.org/p/v8/issues/detail?id=2869
   const unleakIfString = (x) => _.isString(x) ? ` ${x}`.substr(1) : x;


### PR DESCRIPTION
Node does not work as the code assumes it does. If a module is not found locally the system does not, by some magic, look at the globally installed modules (see https://github.com/nodejs/node/issues/3865).

I tried to find a published package that does this but didn't find anything I was particularly confident of. And the actual code is pretty simple.

This PR adds a little utility function (currently not exported, since we don't have any need for it anywhere else) to find the global package and load it.

This ought to finally solve https://github.com/appium/appium/issues/11865