### PR TITLE
Link global opencv4nodejs to give access

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,16 +13,15 @@ env:
     - CXX=clang++-5.0
     - CC=clang-5.0
 install:
-  - npm install
   - |
     printf "while [ true ]; do\nsleep 30\necho 'Building OpenCV'\ndone" > ping.sh
     bash ping.sh &
     echo $! > ping.pid
-    npm i opencv4nodejs > /dev/null 2>&1
+    npm i -g opencv4nodejs > /dev/null 2>&1
     kill `cat ping.pid`
+  - npm install
   - npm install --no-save mjpeg-consumer
 script:
-  - npm run test
-  - npm run e2e-test
+  - npm run test && npm run e2e-test
 after_success:
   - npm run coverage

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   "scripts": {
     "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",
     "prepare": "gulp prepublish",
+    "postinstall": "npm ls -g opencv4nodejs --depth=0 && npm link opencv4nodejs",
     "test": "gulp once",
     "watch": "gulp watch",
     "mocha": "mocha",


### PR DESCRIPTION
I do not have the time right now to make the fully generalized solution proposed in #105. However, if `opencv4nodejs` is already globally installed, it can be used by linking into this package. So check and link if it is there, after the install.