### PR TITLE
Add fs constants to our fs object

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -57,13 +57,21 @@ let fs = {
   },
 };
 
+// add the supported `fs` functions
 const simples = [
   'open', 'close', 'access', 'readFile', 'writeFile', 'write', 'read',
   'readlink', 'chmod', 'unlink', 'readdir', 'stat', 'rename', 'lstat',
 ];
-
 for (const s of simples) {
   fs[s] = B.promisify(_fs[s]);
+}
+
+// add the constants from `fs`
+const constants = [
+  'F_OK', 'R_OK', 'W_OK', 'X_OK', 'constants',
+];
+for (const c of constants) {
+  fs[c] = _fs[c];
 }
 
 export { fs };


### PR DESCRIPTION
So we do not need to import Node's `fs` just to do things with our `fs`.