### PR TITLE
add tmpDir arg for tempdir to respect server tmpdir flag

### DIFF
--- a/lib/tempdir.js
+++ b/lib/tempdir.js
@@ -9,12 +9,12 @@ const RDWR_EXCL = cnst.O_CREAT | cnst.O_TRUNC | cnst.O_RDWR | cnst.O_EXCL;
 
 /**
  * @param {?string} tempRootDirectory A path to root directory for temporary space.
- *                                    Defaults to process.env.APPIUM_TEMP_DIR.
- *                                    os.tmpdir() is called if process.env.APPIUM_TEMP_DIR is undefined.
+ *                                    Defaults to process.env.APPIUM_TMP_DIR.
+ *                                    os.tmpdir() is called if process.env.APPIUM_TMP_DIR is undefined.
  *
  * @returns A path to the available directory
  */
-async function tempDir (rootTmpDir = process.env.APPIUM_TEMP_DIR) {
+async function tempDir (rootTmpDir = process.env.APPIUM_TMP_DIR) {
   const now = new Date();
   const filePath = nodePath.join(rootTmpDir || os.tmpdir(),
     [
@@ -41,16 +41,14 @@ async function tempDir (rootTmpDir = process.env.APPIUM_TEMP_DIR) {
  * @param {string|Affixes} rawAffixes
  * @param {?string} defaultPrefix
  * @param {?string} tempRootDirectory Respect tempRootDirectory if this is provided.
- *                               Defaults to process.env.APPIUM_TEMP_DIR
- *                               {null|undefined} force ignore the rocess.env.APPIUM_TEMP_DIR.
+ *                               Defaults to process.env.APPIUM_TMP_DIR
+ *                               {null|undefined} force ignore the rocess.env.APPIUM_TMP_DIR.
  * @returns {string} A path to the temp directory in tempRootDirectory
  */
-async function path (rawAffixes, defaultPrefix, tempRootDirectory = process.env.APPIUM_TEMP_DIR) {
+async function path (rawAffixes, defaultPrefix, tempRootDirectory = process.env.APPIUM_TMP_DIR) {
   const affixes = parseAffixes(rawAffixes, defaultPrefix);
   const name = [affixes.prefix, affixes.suffix].join('');
   const tempDirectory = await tempDir(tempRootDirectory);
-  log.debug(`========[path] Use given tempRootDirectory in '${tempRootDirectory}'`);
-  log.debug(`========[path] Return: '${nodePath.join(tempDirectory, name)}'`);
   return nodePath.join(tempDirectory, name);
 }
 
@@ -64,13 +62,12 @@ async function path (rawAffixes, defaultPrefix, tempRootDirectory = process.env.
  *
  * @param {Affixes} affixes
  * @param {?string} tempRootDirectory Respect tempRootDirectory if this is provided.
- *                               Defaults to process.env.APPIUM_TEMP_DIR
- *                               {null|undefined} force ignore the rocess.env.APPIUM_TEMP_DIR.
+ *                               Defaults to process.env.APPIUM_TMP_DIR
+ *                               {null|undefined} force ignore the rocess.env.APPIUM_TMP_DIR.
  * @returns {OpenedAffixes}
  */
-async function open (affixes, tempRootDirectory = process.env.APPIUM_TEMP_DIR) {
+async function open (affixes, tempRootDirectory = process.env.APPIUM_TMP_DIR) {
   const filePath = await path(affixes, 'f-', tempRootDirectory);
-  log.debug(`========[open] Open: '${filePath}'`);
   try {
     let fd = await fs.open(filePath, RDWR_EXCL, 0o600);
     // opens the file in mode 384
@@ -110,13 +107,12 @@ const _static = tempDir();
 /**
  * Returns a new path to temp directory every call
  * @param {?string} tempRootDirectory Respect tempRootDirectory if this is provided.
- *                               Defaults to process.env.APPIUM_TEMP_DIR.
- *                               {null|undefined} force ignore the rocess.env.APPIUM_TEMP_DIR.
+ *                               Defaults to process.env.APPIUM_TMP_DIR.
+ *                               {null|undefined} force ignore the rocess.env.APPIUM_TMP_DIR.
  * @returns {string} A new tempDir() if tempRootDirectory is not provided
  */
-async function openDir (tempRootDirectory = process.env.APPIUM_TEMP_DIR) {
+async function openDir (tempRootDirectory = process.env.APPIUM_TMP_DIR) {
   const tempDirectory = await tempDir(tempRootDirectory);
-  log.debug(`========[openDir] Return: '${tempDirectory}'`);
   return tempDirectory;
 }
 
@@ -125,21 +121,7 @@ async function openDir (tempRootDirectory = process.env.APPIUM_TEMP_DIR) {
  * @returns {string} A temp directory path which is static in the same process.
  */
 async function staticDir () { // eslint-disable-line require-await
-  log.debug('========[staticDir]');
-
   return _static;
 }
 
-/**
- * Remove an arbitrary temp directory.
- * If process.env.APPIUM_TEMP_DIR is provided, nothing happens
- * since the method respects the preference
- * @param {*} path
- */
-async function rimTmpDir (path) {
-  if (!process.env.APPIUM_TEMP_DIR) {
-    return await fs.rimraf(path);
-  }
-}
-
-export { open, path, openDir, staticDir, rimTmpDir };
+export { open, path, openDir, staticDir };

--- a/lib/tempdir.js
+++ b/lib/tempdir.js
@@ -39,7 +39,7 @@ async function tempDir () {
  * @param {?string} tempDirectory Respect tempDirectory if this is provided.
  * @returns {string} A path to the temp directory in tempDirectory
  */
-async function path (rawAffixes, defaultPrefix, tempDirectory = null) {
+async function path (rawAffixes, defaultPrefix, tempDirectory = process.env.APPIUM_TEMP_DIR) {
   let affixes = parseAffixes(rawAffixes, defaultPrefix);
   let name = [affixes.prefix, affixes.suffix].join('');
   if (!tempDirectory) {
@@ -63,7 +63,7 @@ async function path (rawAffixes, defaultPrefix, tempDirectory = null) {
  * @param {string} tempDirectory
  * @returns {OpenedAffixes}
  */
-async function open (affixes, tempDirectory = null) {
+async function open (affixes, tempDirectory = process.env.APPIUM_TEMP_DIR) {
   let filePath = await path(affixes, 'f-', tempDirectory);
   try {
     let fd = await fs.open(filePath, RDWR_EXCL, 0o600);
@@ -107,7 +107,7 @@ const openDir = tempDir;
  * @param {string} tempDirectory
  * @returns {string} A new tempDir() if tempDirectory is not provided
  */
-async function staticDir (tempDirectory = null) { // eslint-disable-line require-await
+async function staticDir (tempDirectory = process.env.APPIUM_TEMP_DIR) { // eslint-disable-line require-await
   if (!tempDirectory) {
     tempDirectory = _static;
     log.debug(`Create a new tempDir in '${tempDirectory}'`);

--- a/lib/tempdir.js
+++ b/lib/tempdir.js
@@ -44,6 +44,9 @@ async function path (rawAffixes, defaultPrefix, tempDirectory = null) {
   let name = [affixes.prefix, affixes.suffix].join('');
   if (!tempDirectory) {
     tempDirectory = await tempDir();
+    log.debug(`Create a new tempDir in '${tempDirectory}'`);
+  } else {
+    log.debug(`Use given tempDirectory in '${tempDirectory}'`);
   }
   return nodePath.join(tempDirectory, name);
 }
@@ -106,7 +109,10 @@ const openDir = tempDir;
  */
 async function staticDir (tempDirectory = null) { // eslint-disable-line require-await
   if (!tempDirectory) {
-    return _static;
+    tempDirectory = _static;
+    log.debug(`Create a new tempDir in '${tempDirectory}'`);
+  } else {
+    log.debug(`Use given tempDirectory in '${tempDirectory}'`);
   }
   return tempDirectory;
 }

--- a/lib/tempdir.js
+++ b/lib/tempdir.js
@@ -39,7 +39,9 @@ async function tempDir () {
  * @param {?string} tempDirectory Respect tempDirectory if this is provided.
  * @returns {string} A path to the temp directory in tempDirectory
  */
-async function path (rawAffixes, defaultPrefix, tempDirectory = process.env.APPIUM_TEMP_DIR) {
+async function path (rawAffixes, defaultPrefix, respectTempDir = true) {
+  let tempDirectory = respectTempDir ? process.env.APPIUM_TEMP_DIR : null;
+
   let affixes = parseAffixes(rawAffixes, defaultPrefix);
   let name = [affixes.prefix, affixes.suffix].join('');
   if (!tempDirectory) {
@@ -63,8 +65,8 @@ async function path (rawAffixes, defaultPrefix, tempDirectory = process.env.APPI
  * @param {string} tempDirectory
  * @returns {OpenedAffixes}
  */
-async function open (affixes, tempDirectory = process.env.APPIUM_TEMP_DIR) {
-  let filePath = await path(affixes, 'f-', tempDirectory);
+async function open (affixes, respectTempDir = true) {
+  let filePath = await path(affixes, 'f-', respectTempDir);
   try {
     let fd = await fs.open(filePath, RDWR_EXCL, 0o600);
     // opens the file in mode 384
@@ -107,7 +109,9 @@ const openDir = tempDir;
  * @param {string} tempDirectory
  * @returns {string} A new tempDir() if tempDirectory is not provided
  */
-async function staticDir (tempDirectory = process.env.APPIUM_TEMP_DIR) { // eslint-disable-line require-await
+async function staticDir (respectTempDir = false) { // eslint-disable-line require-await
+  let tempDirectory = respectTempDir ? process.env.APPIUM_TEMP_DIR : null;
+
   if (!tempDirectory) {
     tempDirectory = _static;
     log.debug(`Create a new tempDir in '${tempDirectory}'`);

--- a/lib/tempdir.js
+++ b/lib/tempdir.js
@@ -8,11 +8,15 @@ import log from './logger';
 const RDWR_EXCL = cnst.O_CREAT | cnst.O_TRUNC | cnst.O_RDWR | cnst.O_EXCL;
 
 /**
+ * @param {?string} tempRootDirectory A path to root directory for temporary space.
+ *                                    Defaults to process.env.APPIUM_TEMP_DIR.
+ *                                    os.tmpdir() is called if process.env.APPIUM_TEMP_DIR is undefined.
+ *
  * @returns A path to the available directory
  */
-async function tempDir () {
-  let now = new Date();
-  let filePath = nodePath.join(os.tmpdir(),
+async function tempDir (rootTmpDir = process.env.APPIUM_TEMP_DIR) {
+  const now = new Date();
+  const filePath = nodePath.join(rootTmpDir || os.tmpdir(),
     [
       now.getFullYear(), now.getMonth(), now.getDate(),
       '-',
@@ -36,20 +40,17 @@ async function tempDir () {
 /**
  * @param {string|Affixes} rawAffixes
  * @param {?string} defaultPrefix
- * @param {?string} tempDirectory Respect tempDirectory if this is provided.
+ * @param {?string} tempRootDirectory Respect tempRootDirectory if this is provided.
  *                               Defaults to process.env.APPIUM_TEMP_DIR
  *                               {null|undefined} force ignore the rocess.env.APPIUM_TEMP_DIR.
- * @returns {string} A path to the temp directory in tempDirectory
+ * @returns {string} A path to the temp directory in tempRootDirectory
  */
-async function path (rawAffixes, defaultPrefix, tempDirectory = process.env.APPIUM_TEMP_DIR) {
-  let affixes = parseAffixes(rawAffixes, defaultPrefix);
-  let name = [affixes.prefix, affixes.suffix].join('');
-  if (!tempDirectory) {
-    tempDirectory = await tempDir();
-    log.debug(`Create a new tempDir in '${tempDirectory}'`);
-  } else {
-    log.debug(`Use given tempDirectory in '${tempDirectory}'`);
-  }
+async function path (rawAffixes, defaultPrefix, tempRootDirectory = process.env.APPIUM_TEMP_DIR) {
+  const affixes = parseAffixes(rawAffixes, defaultPrefix);
+  const name = [affixes.prefix, affixes.suffix].join('');
+  const tempDirectory = await tempDir(tempRootDirectory);
+  log.debug(`========[path] Use given tempRootDirectory in '${tempRootDirectory}'`);
+  log.debug(`========[path] Return: '${nodePath.join(tempDirectory, name)}'`);
   return nodePath.join(tempDirectory, name);
 }
 
@@ -62,13 +63,14 @@ async function path (rawAffixes, defaultPrefix, tempDirectory = process.env.APPI
 /**
  *
  * @param {Affixes} affixes
- * @param {?string} tempDirectory Respect tempDirectory if this is provided.
+ * @param {?string} tempRootDirectory Respect tempRootDirectory if this is provided.
  *                               Defaults to process.env.APPIUM_TEMP_DIR
  *                               {null|undefined} force ignore the rocess.env.APPIUM_TEMP_DIR.
  * @returns {OpenedAffixes}
  */
-async function open (affixes, tempDirectory = process.env.APPIUM_TEMP_DIR) {
-  let filePath = await path(affixes, 'f-', tempDirectory);
+async function open (affixes, tempRootDirectory = process.env.APPIUM_TEMP_DIR) {
+  const filePath = await path(affixes, 'f-', tempRootDirectory);
+  log.debug(`========[open] Open: '${filePath}'`);
   try {
     let fd = await fs.open(filePath, RDWR_EXCL, 0o600);
     // opens the file in mode 384
@@ -107,18 +109,14 @@ const _static = tempDir();
 
 /**
  * Returns a new path to temp directory every call
- * @param {?string} tempDirectory Respect tempDirectory if this is provided.
+ * @param {?string} tempRootDirectory Respect tempRootDirectory if this is provided.
  *                               Defaults to process.env.APPIUM_TEMP_DIR.
  *                               {null|undefined} force ignore the rocess.env.APPIUM_TEMP_DIR.
- * @returns {string} A new tempDir() if tempDirectory is not provided
+ * @returns {string} A new tempDir() if tempRootDirectory is not provided
  */
-async function openDir (tempDirectory = process.env.APPIUM_TEMP_DIR) {
-  if (!tempDirectory) {
-    tempDirectory = await tempDir();
-    log.debug(`Create a new tempDir in '${tempDirectory}'`);
-  } else {
-    log.debug(`Use given tempDirectory in '${tempDirectory}'`);
-  }
+async function openDir (tempRootDirectory = process.env.APPIUM_TEMP_DIR) {
+  const tempDirectory = await tempDir(tempRootDirectory);
+  log.debug(`========[openDir] Return: '${tempDirectory}'`);
   return tempDirectory;
 }
 
@@ -127,7 +125,21 @@ async function openDir (tempDirectory = process.env.APPIUM_TEMP_DIR) {
  * @returns {string} A temp directory path which is static in the same process.
  */
 async function staticDir () { // eslint-disable-line require-await
+  log.debug('========[staticDir]');
+
   return _static;
 }
 
-export { open, path, openDir, staticDir };
+/**
+ * Remove an arbitrary temp directory.
+ * If process.env.APPIUM_TEMP_DIR is provided, nothing happens
+ * since the method respects the preference
+ * @param {*} path
+ */
+async function rimTmpDir (path) {
+  if (!process.env.APPIUM_TEMP_DIR) {
+    return await fs.rimraf(path);
+  }
+}
+
+export { open, path, openDir, staticDir, rimTmpDir };

--- a/lib/tempdir.js
+++ b/lib/tempdir.js
@@ -8,14 +8,10 @@ import log from './logger';
 const RDWR_EXCL = cnst.O_CREAT | cnst.O_TRUNC | cnst.O_RDWR | cnst.O_EXCL;
 
 /**
- * Generate a temporary directory in os.tempdir() or tempRootDirectory.
+ * Generate a temporary directory in os.tempdir() or process.env.APPIUM_TMP_DIR.
  * e.g.
  * - No `process.env.APPIUM_TMP_DIR`: `/var/folders/34/2222sh8n27d6rcp7jqlkw8km0000gn/T/xxxxxxxx.yyyy`
  * - With `process.env.APPIUM_TMP_DIR = '/path/to/root'`: `/path/to/root/xxxxxxxx.yyyy`
- *
- * @param {?string} tempRootDirectory A path to a root directory for the temporary directory.
- *                                    Defaults to process.env.APPIUM_TMP_DIR.
- *                                    os.tmpdir() is called if process.env.APPIUM_TMP_DIR is undefined.
  *
  * @returns {string} A path to the temporary directory
  */
@@ -52,7 +48,7 @@ async function tempDir () {
  */
 async function path (rawAffixes, defaultPrefix) {
   const affixes = parseAffixes(rawAffixes, defaultPrefix);
-  const name = [affixes.prefix, affixes.suffix].join('');
+  const name = `${affixes.prefix}${affixes.suffix}`;
   const tempDirectory = await tempDir();
   return nodePath.join(tempDirectory, name);
 }

--- a/lib/tempdir.js
+++ b/lib/tempdir.js
@@ -10,8 +10,8 @@ const RDWR_EXCL = cnst.O_CREAT | cnst.O_TRUNC | cnst.O_RDWR | cnst.O_EXCL;
 /**
  * Generate a temporary directory in os.tempdir() or tempRootDirectory.
  * e.g.
- * - No `rootTmpDir`: `/var/folders/34/2222sh8n27d6rcp7jqlkw8km0000gn/T/xxxxxxxx.yyyy`
- * - With `rootTmpDir = '/path/to/root'`: `/path/to/root/xxxxxxxx.yyyy`
+ * - No `process.env.APPIUM_TMP_DIR`: `/var/folders/34/2222sh8n27d6rcp7jqlkw8km0000gn/T/xxxxxxxx.yyyy`
+ * - With `process.env.APPIUM_TMP_DIR = '/path/to/root'`: `/path/to/root/xxxxxxxx.yyyy`
  *
  * @param {?string} tempRootDirectory A path to a root directory for the temporary directory.
  *                                    Defaults to process.env.APPIUM_TMP_DIR.
@@ -19,9 +19,9 @@ const RDWR_EXCL = cnst.O_CREAT | cnst.O_TRUNC | cnst.O_RDWR | cnst.O_EXCL;
  *
  * @returns {string} A path to the temporary directory
  */
-async function tempDir (rootTmpDir = process.env.APPIUM_TMP_DIR) {
+async function tempDir () {
   const now = new Date();
-  const filePath = nodePath.join(rootTmpDir || os.tmpdir(),
+  const filePath = nodePath.join(process.env.APPIUM_TMP_DIR || os.tmpdir(),
     [
       now.getFullYear(), now.getMonth(), now.getDate(),
       '-',
@@ -43,19 +43,17 @@ async function tempDir (rootTmpDir = process.env.APPIUM_TMP_DIR) {
  */
 
 /**
- * Generate a temporary directory in os.tempdir() or tempRootDirectory
+ * Generate a temporary directory in os.tempdir() or process.env.APPIUM_TMP_DIR
  * with arbitrary prefix/suffix for the directory name.
  *
  * @param {string|Affixes} rawAffixes
  * @param {?string} defaultPrefix
- * @param {?string} tempRootDirectory A path to a root directory for the temporary directory.
- *                                    Defaults to process.env.APPIUM_TMP_DIR.
  * @returns {string}  A path to the temporary directory with rawAffixes and defaultPrefix
  */
-async function path (rawAffixes, defaultPrefix, tempRootDirectory = process.env.APPIUM_TMP_DIR) {
+async function path (rawAffixes, defaultPrefix) {
   const affixes = parseAffixes(rawAffixes, defaultPrefix);
   const name = [affixes.prefix, affixes.suffix].join('');
-  const tempDirectory = await tempDir(tempRootDirectory);
+  const tempDirectory = await tempDir();
   return nodePath.join(tempDirectory, name);
 }
 
@@ -66,16 +64,14 @@ async function path (rawAffixes, defaultPrefix, tempRootDirectory = process.env.
  */
 
 /**
- * Generate a temporary directory in os.tempdir() or tempRootDirectory
+ * Generate a temporary directory in os.tempdir() or process.env.APPIUM_TMP_DIR
  * with arbitrary prefix/suffix for the directory name and return it as open.
  *
  * @param {Affixes} affixes
- * @param {?string} tempRootDirectory A path to a root directory for the temporary directory.
- *                                    Defaults to process.env.APPIUM_TMP_DIR.
  * @returns {OpenedAffixes}
  */
-async function open (affixes, tempRootDirectory = process.env.APPIUM_TMP_DIR) {
-  const filePath = await path(affixes, 'f-', tempRootDirectory);
+async function open (affixes) {
+  const filePath = await path(affixes, 'f-');
   try {
     let fd = await fs.open(filePath, RDWR_EXCL, 0o600);
     // opens the file in mode 384
@@ -117,13 +113,9 @@ const _static = tempDir();
 /**
  * Returns a new path to a temporary directory
  *
- * @param {?string} tempRootDirectory A path to a root directory for the temporary directory.
- *                                    Defaults to process.env.APPIUM_TMP_DIR.
  * @returns {string} A new tempDir() if tempRootDirectory is not provided
  */
-async function openDir (tempRootDirectory = process.env.APPIUM_TMP_DIR) {
-  return await tempDir(tempRootDirectory);
-}
+const openDir = tempDir;
 
 /**
  * Returns a path to a temporary directory whcih is defined as static in the same process

--- a/lib/tempdir.js
+++ b/lib/tempdir.js
@@ -9,6 +9,9 @@ const RDWR_EXCL = cnst.O_CREAT | cnst.O_TRUNC | cnst.O_RDWR | cnst.O_EXCL;
 
 /**
  * Generate a temporary directory in os.tempdir() or tempRootDirectory.
+ * e.g.
+ * - No `rootTmpDir`: `/var/folders/34/2222sh8n27d6rcp7jqlkw8km0000gn/T/xxxxxxxx.yyyy`
+ * - With `rootTmpDir = '/path/to/root'`: `/path/to/root/xxxxxxxx.yyyy`
  *
  * @param {?string} tempRootDirectory A path to a root directory for the temporary directory.
  *                                    Defaults to process.env.APPIUM_TMP_DIR.
@@ -40,6 +43,9 @@ async function tempDir (rootTmpDir = process.env.APPIUM_TMP_DIR) {
  */
 
 /**
+ * Generate a temporary directory in os.tempdir() or tempRootDirectory
+ * with arbitrary prefix/suffix for the directory name.
+ *
  * @param {string|Affixes} rawAffixes
  * @param {?string} defaultPrefix
  * @param {?string} tempRootDirectory A path to a root directory for the temporary directory.
@@ -60,6 +66,8 @@ async function path (rawAffixes, defaultPrefix, tempRootDirectory = process.env.
  */
 
 /**
+ * Generate a temporary directory in os.tempdir() or tempRootDirectory
+ * with arbitrary prefix/suffix for the directory name and return it as open.
  *
  * @param {Affixes} affixes
  * @param {?string} tempRootDirectory A path to a root directory for the temporary directory.
@@ -78,6 +86,8 @@ async function open (affixes, tempRootDirectory = process.env.APPIUM_TMP_DIR) {
 }
 
 /**
+ *
+ * Returns prefix/suffix object
  *
  * @param {string|Affixes} rawAffixes
  * @param {?string} defaultPrefix
@@ -106,6 +116,7 @@ const _static = tempDir();
 
 /**
  * Returns a new path to a temporary directory
+ *
  * @param {?string} tempRootDirectory A path to a root directory for the temporary directory.
  *                                    Defaults to process.env.APPIUM_TMP_DIR.
  * @returns {string} A new tempDir() if tempRootDirectory is not provided
@@ -116,6 +127,7 @@ async function openDir (tempRootDirectory = process.env.APPIUM_TMP_DIR) {
 
 /**
  * Returns a path to a temporary directory whcih is defined as static in the same process
+ *
  * @returns {string} A temp directory path whcih is defined as static in the same process
  */
 async function staticDir () { // eslint-disable-line require-await

--- a/lib/tempdir.js
+++ b/lib/tempdir.js
@@ -48,7 +48,7 @@ async function tempDir () {
  */
 async function path (rawAffixes, defaultPrefix) {
   const affixes = parseAffixes(rawAffixes, defaultPrefix);
-  const name = [affixes.prefix, affixes.suffix].join(''); // ignore undefined
+  const name = `${affixes.prefix || ''}${affixes.suffix || ''}`;
   const tempDirectory = await tempDir();
   return nodePath.join(tempDirectory, name);
 }

--- a/lib/tempdir.js
+++ b/lib/tempdir.js
@@ -48,7 +48,7 @@ async function tempDir () {
  */
 async function path (rawAffixes, defaultPrefix) {
   const affixes = parseAffixes(rawAffixes, defaultPrefix);
-  const name = `${affixes.prefix}${affixes.suffix}`;
+  const name = [affixes.prefix, affixes.suffix].join(''); // ignore undefined
   const tempDirectory = await tempDir();
   return nodePath.join(tempDirectory, name);
 }

--- a/lib/tempdir.js
+++ b/lib/tempdir.js
@@ -8,11 +8,13 @@ import log from './logger';
 const RDWR_EXCL = cnst.O_CREAT | cnst.O_TRUNC | cnst.O_RDWR | cnst.O_EXCL;
 
 /**
- * @param {?string} tempRootDirectory A path to root directory for temporary space.
+ * Generate a temporary directory in os.tempdir() or tempRootDirectory.
+ *
+ * @param {?string} tempRootDirectory A path to a root directory for the temporary directory.
  *                                    Defaults to process.env.APPIUM_TMP_DIR.
  *                                    os.tmpdir() is called if process.env.APPIUM_TMP_DIR is undefined.
  *
- * @returns A path to the available directory
+ * @returns {string} A path to the temporary directory
  */
 async function tempDir (rootTmpDir = process.env.APPIUM_TMP_DIR) {
   const now = new Date();
@@ -40,10 +42,9 @@ async function tempDir (rootTmpDir = process.env.APPIUM_TMP_DIR) {
 /**
  * @param {string|Affixes} rawAffixes
  * @param {?string} defaultPrefix
- * @param {?string} tempRootDirectory Respect tempRootDirectory if this is provided.
- *                               Defaults to process.env.APPIUM_TMP_DIR
- *                               {null|undefined} force ignore the rocess.env.APPIUM_TMP_DIR.
- * @returns {string} A path to the temp directory in tempRootDirectory
+ * @param {?string} tempRootDirectory A path to a root directory for the temporary directory.
+ *                                    Defaults to process.env.APPIUM_TMP_DIR.
+ * @returns {string}  A path to the temporary directory with rawAffixes and defaultPrefix
  */
 async function path (rawAffixes, defaultPrefix, tempRootDirectory = process.env.APPIUM_TMP_DIR) {
   const affixes = parseAffixes(rawAffixes, defaultPrefix);
@@ -61,9 +62,8 @@ async function path (rawAffixes, defaultPrefix, tempRootDirectory = process.env.
 /**
  *
  * @param {Affixes} affixes
- * @param {?string} tempRootDirectory Respect tempRootDirectory if this is provided.
- *                               Defaults to process.env.APPIUM_TMP_DIR
- *                               {null|undefined} force ignore the rocess.env.APPIUM_TMP_DIR.
+ * @param {?string} tempRootDirectory A path to a root directory for the temporary directory.
+ *                                    Defaults to process.env.APPIUM_TMP_DIR.
  * @returns {OpenedAffixes}
  */
 async function open (affixes, tempRootDirectory = process.env.APPIUM_TMP_DIR) {
@@ -105,20 +105,18 @@ function parseAffixes (rawAffixes, defaultPrefix) {
 const _static = tempDir();
 
 /**
- * Returns a new path to temp directory every call
- * @param {?string} tempRootDirectory Respect tempRootDirectory if this is provided.
- *                               Defaults to process.env.APPIUM_TMP_DIR.
- *                               {null|undefined} force ignore the rocess.env.APPIUM_TMP_DIR.
+ * Returns a new path to a temporary directory
+ * @param {?string} tempRootDirectory A path to a root directory for the temporary directory.
+ *                                    Defaults to process.env.APPIUM_TMP_DIR.
  * @returns {string} A new tempDir() if tempRootDirectory is not provided
  */
 async function openDir (tempRootDirectory = process.env.APPIUM_TMP_DIR) {
-  const tempDirectory = await tempDir(tempRootDirectory);
-  return tempDirectory;
+  return await tempDir(tempRootDirectory);
 }
 
 /**
- * Returns a path to temp directory whcih is static in the same process.
- * @returns {string} A temp directory path which is static in the same process.
+ * Returns a path to a temporary directory whcih is defined as static in the same process
+ * @returns {string} A temp directory path whcih is defined as static in the same process
  */
 async function staticDir () { // eslint-disable-line require-await
   return _static;

--- a/lib/tempdir.js
+++ b/lib/tempdir.js
@@ -7,6 +7,9 @@ import log from './logger';
 
 const RDWR_EXCL = cnst.O_CREAT | cnst.O_TRUNC | cnst.O_RDWR | cnst.O_EXCL;
 
+/**
+ * @returns A path to the available directory
+ */
 async function tempDir () {
   let now = new Date();
   let filePath = nodePath.join(os.tmpdir(),
@@ -24,15 +27,41 @@ async function tempDir () {
   return filePath;
 }
 
-async function path (rawAffixes, defaultPrefix) {
+/**
+ * @typedef {Object} Affixes
+ * @property {string} prefix - prefix of the temp directory name
+ * @property {string} suffix - suffix of the temp directory name
+ */
+
+/**
+ * @param {string|Affixes} rawAffixes
+ * @param {?string} defaultPrefix
+ * @param {?string} tempDirectory Respect tempDirectory if this is provided.
+ * @returns {string} A path to the temp directory in tempDirectory
+ */
+async function path (rawAffixes, defaultPrefix, tempDirectory = null) {
   let affixes = parseAffixes(rawAffixes, defaultPrefix);
   let name = [affixes.prefix, affixes.suffix].join('');
-  let tempDirectory = await tempDir();
+  if (!tempDirectory) {
+    tempDirectory = await tempDir();
+  }
   return nodePath.join(tempDirectory, name);
 }
 
-async function open (affixes) {
-  let filePath = await path(affixes, 'f-');
+/**
+ * @typedef {Object} OpenedAffixes
+ * @property {string} path - The path to file
+ * @property {integer} fd - The file descriptor opened
+ */
+
+/**
+ *
+ * @param {Affixes} affixes
+ * @param {string} tempDirectory
+ * @returns {OpenedAffixes}
+ */
+async function open (affixes, tempDirectory = null) {
+  let filePath = await path(affixes, 'f-', tempDirectory);
   try {
     let fd = await fs.open(filePath, RDWR_EXCL, 0o600);
     // opens the file in mode 384
@@ -40,9 +69,14 @@ async function open (affixes) {
   } catch (err) {
     log.errorAndThrow(err);
   }
-
 }
 
+/**
+ *
+ * @param {string|Affixes} rawAffixes
+ * @param {?string} defaultPrefix
+ * @returns {Affixes}
+ */
 function parseAffixes (rawAffixes, defaultPrefix) {
   let affixes = {prefix: null, suffix: null};
   if (rawAffixes) {
@@ -65,8 +99,16 @@ function parseAffixes (rawAffixes, defaultPrefix) {
 const _static = tempDir();
 const openDir = tempDir;
 
-async function staticDir () { // eslint-disable-line require-await
-  return _static;
+/**
+ * Returns a path to temp directory
+ * @param {string} tempDirectory
+ * @returns {string} A new tempDir() if tempDirectory is not provided
+ */
+async function staticDir (tempDirectory = null) { // eslint-disable-line require-await
+  if (!tempDirectory) {
+    return _static;
+  }
+  return tempDirectory;
 }
 
 export { open, path, openDir, staticDir };

--- a/lib/tempdir.js
+++ b/lib/tempdir.js
@@ -37,11 +37,11 @@ async function tempDir () {
  * @param {string|Affixes} rawAffixes
  * @param {?string} defaultPrefix
  * @param {?string} tempDirectory Respect tempDirectory if this is provided.
+ *                               Defaults to process.env.APPIUM_TEMP_DIR
+ *                               {null|undefined} force ignore the rocess.env.APPIUM_TEMP_DIR.
  * @returns {string} A path to the temp directory in tempDirectory
  */
-async function path (rawAffixes, defaultPrefix, respectTempDir = true) {
-  let tempDirectory = respectTempDir ? process.env.APPIUM_TEMP_DIR : null;
-
+async function path (rawAffixes, defaultPrefix, tempDirectory = process.env.APPIUM_TEMP_DIR) {
   let affixes = parseAffixes(rawAffixes, defaultPrefix);
   let name = [affixes.prefix, affixes.suffix].join('');
   if (!tempDirectory) {
@@ -62,11 +62,13 @@ async function path (rawAffixes, defaultPrefix, respectTempDir = true) {
 /**
  *
  * @param {Affixes} affixes
- * @param {string} tempDirectory
+ * @param {?string} tempDirectory Respect tempDirectory if this is provided.
+ *                               Defaults to process.env.APPIUM_TEMP_DIR
+ *                               {null|undefined} force ignore the rocess.env.APPIUM_TEMP_DIR.
  * @returns {OpenedAffixes}
  */
-async function open (affixes, respectTempDir = true) {
-  let filePath = await path(affixes, 'f-', respectTempDir);
+async function open (affixes, tempDirectory = process.env.APPIUM_TEMP_DIR) {
+  let filePath = await path(affixes, 'f-', tempDirectory);
   try {
     let fd = await fs.open(filePath, RDWR_EXCL, 0o600);
     // opens the file in mode 384
@@ -102,23 +104,30 @@ function parseAffixes (rawAffixes, defaultPrefix) {
 }
 
 const _static = tempDir();
-const openDir = tempDir;
 
 /**
- * Returns a path to temp directory
- * @param {string} tempDirectory
+ * Returns a new path to temp directory every call
+ * @param {?string} tempDirectory Respect tempDirectory if this is provided.
+ *                               Defaults to process.env.APPIUM_TEMP_DIR.
+ *                               {null|undefined} force ignore the rocess.env.APPIUM_TEMP_DIR.
  * @returns {string} A new tempDir() if tempDirectory is not provided
  */
-async function staticDir (respectTempDir = false) { // eslint-disable-line require-await
-  let tempDirectory = respectTempDir ? process.env.APPIUM_TEMP_DIR : null;
-
+async function openDir (tempDirectory = process.env.APPIUM_TEMP_DIR) {
   if (!tempDirectory) {
-    tempDirectory = _static;
+    tempDirectory = await tempDir();
     log.debug(`Create a new tempDir in '${tempDirectory}'`);
   } else {
     log.debug(`Use given tempDirectory in '${tempDirectory}'`);
   }
   return tempDirectory;
+}
+
+/**
+ * Returns a path to temp directory whcih is static in the same process.
+ * @returns {string} A temp directory path which is static in the same process.
+ */
+async function staticDir () { // eslint-disable-line require-await
+  return _static;
 }
 
 export { open, path, openDir, staticDir };

--- a/test/tempdir-specs.js
+++ b/test/tempdir-specs.js
@@ -1,14 +1,23 @@
 
 import { tempDir, fs } from '../index.js';
 import chai from 'chai';
+import nodePath from 'path';
 
 chai.should();
 
 describe('tempdir', function () {
   it('should be able to generate a path', async function () {
-    let path = await tempDir.path({prefix: 'myfile', suffix: '.tmp'});
+    const path = await tempDir.path({prefix: 'myfile', suffix: '.tmp'});
     path.should.exist;
     path.should.include('myfile.tmp');
+  });
+
+  it('should be able to generate a path with tempDirectory', async function () {
+    const preDirPath = await tempDir.staticDir();
+
+    const path = await tempDir.path({prefix: 'myfile', suffix: '.tmp'}, undefined, preDirPath);
+    path.should.exist;
+    path.should.equal(nodePath.join(preDirPath, 'myfile.tmp'));
   });
 
   it('should be able to create a temp file', async function () {
@@ -16,6 +25,17 @@ describe('tempdir', function () {
     res.should.exist;
     res.path.should.exist;
     res.path.should.include('my-test-file.zip');
+    res.fd.should.exist;
+    await fs.exists(res.path).should.eventually.be.ok;
+  });
+
+  it('should be able to create a temp file with tempDirectory', async function () {
+    const preDirPath = await tempDir.staticDir();
+
+    let res = await tempDir.open({prefix: 'my-test-file', suffix: '.zip'}, preDirPath);
+    res.should.exist;
+    res.path.should.exist;
+    res.path.should.equal(nodePath.join(preDirPath, 'my-test-file.zip'));
     res.fd.should.exist;
     await fs.exists(res.path).should.eventually.be.ok;
   });
@@ -36,5 +56,18 @@ describe('tempdir', function () {
     let res2 = await tempDir.staticDir();
     await fs.exists(res2).should.eventually.be.ok;
     res.should.equal(res2);
+  });
+
+  it('should generate one temp dir used for the life of the process with tempDirectory', async function () {
+    const preDirPath = await tempDir.staticDir();
+
+    let res = await tempDir.staticDir(preDirPath);
+    res.should.be.a('string');
+    await fs.exists(res).should.eventually.be.ok;
+    let res2 = await tempDir.staticDir(preDirPath);
+    await fs.exists(res2).should.eventually.be.ok;
+    res.should.equal(res2);
+    res.should.equal(preDirPath);
+    res2.should.equal(preDirPath);
   });
 });

--- a/test/tempdir-specs.js
+++ b/test/tempdir-specs.js
@@ -120,7 +120,7 @@ describe('tempdir', function () {
 
     res.should.be.a('string');
     await fs.exists(res).should.eventually.be.ok;
-    let res2 = await tempDir.openDir(null); // or undefined
+    let res2 = await tempDir.openDir(null);
     await fs.exists(res2).should.eventually.be.ok;
     res.should.not.equal(res2);
   });

--- a/test/tempdir-specs.js
+++ b/test/tempdir-specs.js
@@ -8,7 +8,7 @@ chai.should();
 describe('tempdir', function () {
   afterEach(function () {
     // set the process env as undefiend
-    delete process.env.APPIUM_TEMP_DIR;
+    delete process.env.APPIUM_TMP_DIR;
   });
 
   it('should be able to generate a path', async function () {
@@ -26,9 +26,9 @@ describe('tempdir', function () {
     path.should.include('myfile.tmp');
   });
 
-  it('should be able to generate a path with process.env.APPIUM_TEMP_DIR', async function () {
+  it('should be able to generate a path with process.env.APPIUM_TMP_DIR', async function () {
     const preRootDirPath = await tempDir.openDir();
-    process.env.APPIUM_TEMP_DIR = preRootDirPath;
+    process.env.APPIUM_TMP_DIR = preRootDirPath;
 
     const path = await tempDir.path({prefix: 'myfile', suffix: '.tmp'});
     path.should.exist;
@@ -36,9 +36,9 @@ describe('tempdir', function () {
     path.should.include('myfile.tmp');
   });
 
-  it('should be able to generate a path with ignoring process.env.APPIUM_TEMP_DIR', async function () {
+  it('should be able to generate a path with ignoring process.env.APPIUM_TMP_DIR', async function () {
     const preDirPath = await tempDir.openDir();
-    process.env.APPIUM_TEMP_DIR = preDirPath;
+    process.env.APPIUM_TMP_DIR = preDirPath;
 
     const path = await tempDir.path({prefix: 'myfile', suffix: '.tmp'}, undefined, null);
     path.should.exist;
@@ -66,9 +66,9 @@ describe('tempdir', function () {
     await fs.exists(res.path).should.eventually.be.ok;
   });
 
-  it('should be able to create a temp file with process.env.APPIUM_TEMP_DIR', async function () {
+  it('should be able to create a temp file with process.env.APPIUM_TMP_DIR', async function () {
     const preRootDirPath = await tempDir.openDir();
-    process.env.APPIUM_TEMP_DIR = preRootDirPath;
+    process.env.APPIUM_TMP_DIR = preRootDirPath;
 
     let res = await tempDir.open({prefix: 'my-test-file', suffix: '.zip'});
     res.should.exist;
@@ -79,9 +79,9 @@ describe('tempdir', function () {
     await fs.exists(res.path).should.eventually.be.ok;
   });
 
-  it('should be able to create a temp file with ignoring process.env.APPIUM_TEMP_DIR', async function () {
+  it('should be able to create a temp file with ignoring process.env.APPIUM_TMP_DIR', async function () {
     const preDirPath = await tempDir.openDir();
-    process.env.APPIUM_TEMP_DIR = preDirPath;
+    process.env.APPIUM_TMP_DIR = preDirPath;
 
     let res = await tempDir.open({prefix: 'my-test-file', suffix: '.zip'}, null);
     res.should.exist;
@@ -100,9 +100,9 @@ describe('tempdir', function () {
     res.should.not.equal(res2);
   });
 
-  it('should generate a random temp dir, but the same with process.env.APPIUM_TEMP_DIR', async function () {
+  it('should generate a random temp dir, but the same with process.env.APPIUM_TMP_DIR', async function () {
     const preRootDirPath = await tempDir.openDir();
-    process.env.APPIUM_TEMP_DIR = preRootDirPath;
+    process.env.APPIUM_TMP_DIR = preRootDirPath;
 
     const res = await tempDir.openDir();
     res.should.be.a('string');
@@ -114,9 +114,9 @@ describe('tempdir', function () {
     res.should.not.equal(res2);
   });
 
-  it('should generate a random temp dir with ignoring process.env.APPIUM_TEMP_DIR', async function () {
+  it('should generate a random temp dir with ignoring process.env.APPIUM_TMP_DIR', async function () {
     let res = await tempDir.openDir();
-    process.env.APPIUM_TEMP_DIR = res;
+    process.env.APPIUM_TMP_DIR = res;
 
     res.should.be.a('string');
     await fs.exists(res).should.eventually.be.ok;

--- a/test/tempdir-specs.js
+++ b/test/tempdir-specs.js
@@ -18,20 +18,22 @@ describe('tempdir', function () {
   });
 
   it('should be able to generate a path with tempDirectory', async function () {
-    const preDirPath = await tempDir.openDir();
+    const preRootDirPath = await tempDir.openDir();
 
-    const path = await tempDir.path({prefix: 'myfile', suffix: '.tmp'}, undefined, preDirPath);
+    const path = await tempDir.path({prefix: 'myfile', suffix: '.tmp'}, undefined, preRootDirPath);
     path.should.exist;
-    path.should.equal(nodePath.join(preDirPath, 'myfile.tmp'));
+    path.should.include(preRootDirPath);
+    path.should.include('myfile.tmp');
   });
 
   it('should be able to generate a path with process.env.APPIUM_TEMP_DIR', async function () {
-    const preDirPath = await tempDir.openDir();
-    process.env.APPIUM_TEMP_DIR = preDirPath;
+    const preRootDirPath = await tempDir.openDir();
+    process.env.APPIUM_TEMP_DIR = preRootDirPath;
 
     const path = await tempDir.path({prefix: 'myfile', suffix: '.tmp'});
     path.should.exist;
-    path.should.equal(nodePath.join(preDirPath, 'myfile.tmp'));
+    path.should.include(preRootDirPath);
+    path.should.include('myfile.tmp');
   });
 
   it('should be able to generate a path with ignoring process.env.APPIUM_TEMP_DIR', async function () {
@@ -53,24 +55,26 @@ describe('tempdir', function () {
   });
 
   it('should be able to create a temp file with tempDirectory', async function () {
-    const preDirPath = await tempDir.openDir();
+    const preRootDirPath = await tempDir.openDir();
 
-    let res = await tempDir.open({prefix: 'my-test-file', suffix: '.zip'}, preDirPath);
+    let res = await tempDir.open({prefix: 'my-test-file', suffix: '.zip'}, preRootDirPath);
     res.should.exist;
     res.path.should.exist;
-    res.path.should.equal(nodePath.join(preDirPath, 'my-test-file.zip'));
+    res.path.should.include(preRootDirPath);
+    res.path.should.include('my-test-file.zip');
     res.fd.should.exist;
     await fs.exists(res.path).should.eventually.be.ok;
   });
 
   it('should be able to create a temp file with process.env.APPIUM_TEMP_DIR', async function () {
-    const preDirPath = await tempDir.openDir();
-    process.env.APPIUM_TEMP_DIR = preDirPath;
+    const preRootDirPath = await tempDir.openDir();
+    process.env.APPIUM_TEMP_DIR = preRootDirPath;
 
     let res = await tempDir.open({prefix: 'my-test-file', suffix: '.zip'});
     res.should.exist;
     res.path.should.exist;
-    res.path.should.equal(nodePath.join(preDirPath, 'my-test-file.zip'));
+    res.path.should.include(preRootDirPath);
+    res.path.should.include('my-test-file.zip');
     res.fd.should.exist;
     await fs.exists(res.path).should.eventually.be.ok;
   });
@@ -97,14 +101,17 @@ describe('tempdir', function () {
   });
 
   it('should generate a random temp dir, but the same with process.env.APPIUM_TEMP_DIR', async function () {
-    let res = await tempDir.openDir();
-    process.env.APPIUM_TEMP_DIR = res;
+    const preRootDirPath = await tempDir.openDir();
+    process.env.APPIUM_TEMP_DIR = preRootDirPath;
 
+    const res = await tempDir.openDir();
     res.should.be.a('string');
     await fs.exists(res).should.eventually.be.ok;
-    let res2 = await tempDir.openDir();
+    const res2 = await tempDir.openDir();
     await fs.exists(res2).should.eventually.be.ok;
-    res.should.equal(res2);
+    res.should.include(preRootDirPath);
+    res2.should.include(preRootDirPath);
+    res.should.not.equal(res2);
   });
 
   it('should generate a random temp dir with ignoring process.env.APPIUM_TEMP_DIR', async function () {

--- a/test/tempdir-specs.js
+++ b/test/tempdir-specs.js
@@ -1,7 +1,6 @@
 
 import { tempDir, fs } from '../index.js';
 import chai from 'chai';
-import nodePath from 'path';
 
 chai.should();
 
@@ -17,15 +16,6 @@ describe('tempdir', function () {
     path.should.include('myfile.tmp');
   });
 
-  it('should be able to generate a path with tempDirectory', async function () {
-    const preRootDirPath = await tempDir.openDir();
-
-    const path = await tempDir.path({prefix: 'myfile', suffix: '.tmp'}, undefined, preRootDirPath);
-    path.should.exist;
-    path.should.include(preRootDirPath);
-    path.should.include('myfile.tmp');
-  });
-
   it('should be able to generate a path with process.env.APPIUM_TMP_DIR', async function () {
     const preRootDirPath = await tempDir.openDir();
     process.env.APPIUM_TMP_DIR = preRootDirPath;
@@ -36,31 +26,10 @@ describe('tempdir', function () {
     path.should.include('myfile.tmp');
   });
 
-  it('should be able to generate a path with ignoring process.env.APPIUM_TMP_DIR', async function () {
-    const preDirPath = await tempDir.openDir();
-    process.env.APPIUM_TMP_DIR = preDirPath;
-
-    const path = await tempDir.path({prefix: 'myfile', suffix: '.tmp'}, undefined, null);
-    path.should.exist;
-    path.should.not.equal(nodePath.join(preDirPath, 'myfile.tmp'));
-  });
-
   it('should be able to create a temp file', async function () {
     let res = await tempDir.open({prefix: 'my-test-file', suffix: '.zip'});
     res.should.exist;
     res.path.should.exist;
-    res.path.should.include('my-test-file.zip');
-    res.fd.should.exist;
-    await fs.exists(res.path).should.eventually.be.ok;
-  });
-
-  it('should be able to create a temp file with tempDirectory', async function () {
-    const preRootDirPath = await tempDir.openDir();
-
-    let res = await tempDir.open({prefix: 'my-test-file', suffix: '.zip'}, preRootDirPath);
-    res.should.exist;
-    res.path.should.exist;
-    res.path.should.include(preRootDirPath);
     res.path.should.include('my-test-file.zip');
     res.fd.should.exist;
     await fs.exists(res.path).should.eventually.be.ok;
@@ -75,18 +44,6 @@ describe('tempdir', function () {
     res.path.should.exist;
     res.path.should.include(preRootDirPath);
     res.path.should.include('my-test-file.zip');
-    res.fd.should.exist;
-    await fs.exists(res.path).should.eventually.be.ok;
-  });
-
-  it('should be able to create a temp file with ignoring process.env.APPIUM_TMP_DIR', async function () {
-    const preDirPath = await tempDir.openDir();
-    process.env.APPIUM_TMP_DIR = preDirPath;
-
-    let res = await tempDir.open({prefix: 'my-test-file', suffix: '.zip'}, null);
-    res.should.exist;
-    res.path.should.exist;
-    res.path.should.not.equal(nodePath.join(preDirPath, 'my-test-file.zip'));
     res.fd.should.exist;
     await fs.exists(res.path).should.eventually.be.ok;
   });
@@ -111,17 +68,6 @@ describe('tempdir', function () {
     await fs.exists(res2).should.eventually.be.ok;
     res.should.include(preRootDirPath);
     res2.should.include(preRootDirPath);
-    res.should.not.equal(res2);
-  });
-
-  it('should generate a random temp dir with ignoring process.env.APPIUM_TMP_DIR', async function () {
-    let res = await tempDir.openDir();
-    process.env.APPIUM_TMP_DIR = res;
-
-    res.should.be.a('string');
-    await fs.exists(res).should.eventually.be.ok;
-    let res2 = await tempDir.openDir(null);
-    await fs.exists(res2).should.eventually.be.ok;
     res.should.not.equal(res2);
   });
 


### PR DESCRIPTION
I've tested below patterns in [ruby_lib_core test suite](https://github.com/appium/ruby_lib_core/tree/master/test/functional) adding logs in `tempDir` module:

- Run a single device test
    - Android
        - UIA2
        - Espresso
    - iOS
        - XCUITest
- Run tests in parallel in single Appium server instance
    - Android x 3 emulators
        - UIA2
        - Espresso
    - iOS x 2 simulators
        - XCUITest
    - Android x 3, iOS x 2

The ruby_lib_core include screen recording, pull/push apks like https://github.com/appium/appium-android-driver/pull/538

Then, I ensured Appium log had no `/var/folders/xxxx`. They called `--tmp` arg.

----

Working for https://github.com/appium/appium/issues/12527

Appium can get `--tmp` as http://appium.io/docs/en/writing-running-appium/server-args/#server-flags. In some method, the flag is respected.

But methods calls `tempDir` module https://github.com/search?q=org%3Aappium+tempDir&type=Code does not respect it.

@jlipps suggested to me adding an arg to be able to refer the `--tmp` in `tempDir` modules.

After this, I should work to update `tempDir` module called in various repositories.

---

I'll update appium-android repository based on this PR in order to make sure if `--tmp` works expectedly with this change.

(So, currently this PR is just a draft)


----

related PRs:

- https://github.com/appium/appium-android-driver/pull/538
- https://github.com/appium/appium/pull/12585