### PR TITLE
fix typo for occurrences message

### DIFF
--- a/lib/image-util.js
+++ b/lib/image-util.js
@@ -429,6 +429,7 @@ async function getImageOccurrence (fullImgData, partialImgData, options = {}) {
     const matched = await fullImg.matchTemplateAsync(partialImg, cv.TM_CCOEFF_NORMED);
     const minMax = await matched.minMaxLocAsync();
     if (minMax.maxVal < threshold) {
+      // Below error message, `Cannot find any occurrences` is referenced in find by image
       throw new Error(`Cannot find any occurrences of the partial image in the full ` +
                       `image above the threshold of ${threshold}. Highest match value ` +
                       `found was ${minMax.maxVal}`);
@@ -440,7 +441,8 @@ async function getImageOccurrence (fullImgData, partialImgData, options = {}) {
       height: partialImg.rows
     };
   } catch (e) {
-    throw new Error(`Cannot find any occurences of the partial image in the full image. ` +
+    // Below error message, `Cannot find any occurrences` is referenced in find by image
+    throw new Error(`Cannot find any occurrences of the partial image in the full image. ` +
                     `Original error: ${e}`);
   }
   if (visualize) {


### PR DESCRIPTION
I found a typo which is used in _find element by image_ like below:

```
      if (err.message.match(/Cannot find any occurrences/)) {
        return false;
      }
```