### PR TITLE
Add createReadStream and createWriteStream to fs

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -66,6 +66,14 @@ for (const s of simples) {
   fs[s] = B.promisify(_fs[s]);
 }
 
+const syncFunctions = [
+  'createReadStream',
+  'createWriteStream',
+];
+for (const s of syncFunctions) {
+  fs[s] = _fs[s];
+}
+
 // add the constants from `fs`
 const constants = [
   'F_OK', 'R_OK', 'W_OK', 'X_OK', 'constants',


### PR DESCRIPTION
So that we don't need to import both Node's `fs` and ours, to use them.