### PR TITLE
feat: add function to abstract away shell-quote

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -4,6 +4,7 @@ import os from 'os';
 import path from 'path';
 import fs from './fs';
 import semver from 'semver';
+import { quote as shellQuote } from 'shell-quote';
 
 const W3C_WEB_ELEMENT_IDENTIFIER = 'element-6066-11e4-a52e-4f735466cecf';
 
@@ -269,9 +270,20 @@ function compareVersions (ver1, operator, ver2) {
   return operator === '!=' ? !result : result;
 }
 
+/**
+ * Add appropriate quotes to command arguments. See https://github.com/substack/node-shell-quote
+ * for more details
+ *
+ * @param {string|Array<string>} - The arguments that will be parsed
+ * @returns {string} - The arguments, quoted
+ */
+function quote (args) {
+  return shellQuote(args);
+}
+
 export {
   hasValue, escapeSpace, escapeSpecialChars, localIp, cancellableDelay,
   multiResolve, safeJsonParse, wrapElement, unwrapElement, filterObject,
   toReadableSizeString, isSubPath, W3C_WEB_ELEMENT_IDENTIFIER,
-  isSameDestination, compareVersions, coerceVersion,
+  isSameDestination, compareVersions, coerceVersion, quote,
 };

--- a/test/util-specs.js
+++ b/test/util-specs.js
@@ -407,4 +407,27 @@ describe('util', function () {
     });
   });
 
+  describe('quote', function () {
+    it('should quote a string with a space', function () {
+      util.quote(['a', 'b', 'c d']).should.eql('a b \'c d\'');
+    });
+    it('should escape double quotes', function () {
+      util.quote(['a', 'b', `it's a "neat thing"`]).should.eql(`a b "it's a \\"neat thing\\""`);
+    });
+    it("should escape $ ` and '", function () {
+      util.quote(['$', '`', `'`]).should.eql('\\$ \\` "\'"');
+    });
+    it('should handle empty array', function () {
+      util.quote([]).should.eql('');
+    });
+    it('should quote a string with newline', function () {
+      util.quote(['a\nb']).should.eql(`'a\nb'`);
+    });
+    it('should stringify booleans', function () {
+      util.quote(['a', 1, true, false]).should.eql('a 1 true false');
+    });
+    it('should stringify null and undefined', function () {
+      util.quote(['a', 1, null, undefined]).should.eql('a 1 null undefined');
+    });
+  });
 });


### PR DESCRIPTION
Attempt to reduce the footprint of a package we use all over the place. Recently `shell-quote` was updated four times in succession, which means Greenkeeper ran four branches through CI for every package that imports it. If the functionality is verified here, then we can safely use it throughout.