### PR TITLE
fix: Make sure all logged strings are always being unleaked

### DIFF
--- a/lib/logging.js
+++ b/lib/logging.js
@@ -1,5 +1,6 @@
 import npmlog from 'npmlog';
 import _ from 'lodash';
+import { unleakString } from './util';
 
 
 // levels that are available from `npmlog`
@@ -54,33 +55,23 @@ function getLogger (prefix = null) {
     configurable: true
   });
 
-  // This lambda function is necessary to workaround unexpected memory leaks
-  // caused by NodeJS behavior described in https://bugs.chromium.org/p/v8/issues/detail?id=2869
-  const unleakIfString = (x) => _.isString(x) ? ` ${x}`.substr(1) : x;
   // add all the levels from `npmlog`, and map to the underlying logger
   for (const level of NPM_LEVELS) {
     wrappedLogger[level] = function (...args) {
       const actualPrefix = _.isFunction(prefix) ? prefix() : prefix;
-      for (const arg of args.map(unleakIfString)) {
-        let out = arg + '';
-        if (_.isError(arg) && arg.stack) {
-          out = arg.stack;
-        }
+      for (const arg of args) {
+        const out = (_.isError(arg) && arg.stack) ? arg.stack : `${arg}`;
         for (const line of out.split('\n')) {
-          logger[level](actualPrefix, line);
+          logger[level](actualPrefix, unleakString(line));
         }
       }
     };
   }
   // add method to log an error, and throw it, for convenience
   wrappedLogger.errorAndThrow = function (err) {
+    this.error(err);
     // make sure we have an `Error` object. Wrap if necessary
-    if (!(err instanceof Error)) {
-      err = new Error(err);
-    }
-    // log and throw
-    this.error(unleakIfString(err));
-    throw err;
+    throw (_.isError(err) ? err : new Error(unleakString(err)));
   };
   if (!usingGlobalLog) {
     // if we're not using a global log specified from some top-level package,

--- a/lib/util.js
+++ b/lib/util.js
@@ -285,7 +285,7 @@ function quote (args) {
  * This function is necessary to workaround unexpected memory leaks
  * caused by NodeJS string interning
  * behavior described in https://bugs.chromium.org/p/v8/issues/detail?id=2869
- * 
+ *
  * @param {*} s - The string to unleak
  * @return {string} Either the unleaked string or the original object converted to string
  */

--- a/lib/util.js
+++ b/lib/util.js
@@ -281,9 +281,21 @@ function quote (args) {
   return shellQuote(args);
 }
 
+/**
+ * This function is necessary to workaround unexpected memory leaks
+ * caused by NodeJS string interning
+ * behavior described in https://bugs.chromium.org/p/v8/issues/detail?id=2869
+ * 
+ * @param {*} s - The string to unleak
+ * @return {string} Either the unleaked string or the original object converted to string
+ */
+function unleakString (s) {
+  return ` ${s}`.substr(1);
+}
+
 export {
   hasValue, escapeSpace, escapeSpecialChars, localIp, cancellableDelay,
   multiResolve, safeJsonParse, wrapElement, unwrapElement, filterObject,
   toReadableSizeString, isSubPath, W3C_WEB_ELEMENT_IDENTIFIER,
-  isSameDestination, compareVersions, coerceVersion, quote,
+  isSameDestination, compareVersions, coerceVersion, quote, unleakString,
 };

--- a/test/util-specs.js
+++ b/test/util-specs.js
@@ -430,4 +430,18 @@ describe('util', function () {
       util.quote(['a', 1, null, undefined]).should.eql('a 1 null undefined');
     });
   });
+
+  describe('unleakString', function () {
+    it('should unleak a string', function () {
+      util.unleakString('yolo').should.eql('yolo');
+    });
+    it('should unleak a multiline string', function () {
+      util.unleakString(' yolo\nbolo ').should.eql(' yolo\nbolo ');
+    });
+    it('should convert an object to a string', function () {
+      for (const obj of [{}, null, undefined, [], 0]) {
+        util.unleakString(obj).should.eql(`${obj}`);
+      }
+    });
+  });
 });


### PR DESCRIPTION
The system logger keeps the internal records buffer, so when we log some big string or even part of it (by using, for example, substring or split calls) then the whole string is kept in memory until the log buffer is large enough to free up the outdated items. In this PR we make sure that log items are always being unleaked, which means we never keep a pointer to the large string, but rather a separate string object in the log buffer. 

I was also thinking about limiting the maximum length of a single line we can put into the log, to, for example, 1MB. Currently the maximum size of the log buffer is set to 3000 records, which is 3 GB in total if all records would have their maximum sizes.