### PR TITLE
Issue  #13515

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -85,27 +85,34 @@ let fs = {
       throw Error(`'${dir}' is not a valid root directory` + (errMsg ? `. Original error: ${errMsg}` : ''));
     }
 
+    let lastFileProcessed = B.resolve();
     return await new B((resolve, reject) => {
       const walker = klaw(dir, {
         depthLimit: recursive ? -1 : 0
       });
-      walker.on('data', async (item) => {
+      walker.on('data', (item) => {
         walker.pause();
-        try {
-          // eslint-disable-next-line promise/prefer-await-to-callbacks
-          if (await callback(item.path, item.stats.isDirectory())) {
-            resolve(item.path);
+        // eslint-disable-next-line promise/prefer-await-to-callbacks
+        lastFileProcessed = B.try(async () => await callback(item.path, item.stats.isDirectory()))
+          .then(shouldResolve => {
+            if (shouldResolve) {
+              resolve(item.path);
+              walker.destroy();
+            } else {
+              walker.resume();
+            }
+          })
+          .catch(err => {
+            reject(err);
             walker.destroy();
-          } else {
-            walker.resume();
-          }
-        } catch (err) {
-          reject(err);
-          walker.destroy();
-        }
+          });
       })
       .on('error', (err, item) => log.warn(`Got an error while walking '${item.path}': ${err.message}`))
-      .on('end', () => resolve(null));
+      .on('end', () => {
+        lastFileProcessed
+          .then(() => resolve(null))
+          .catch(err => log.warn(`Unexpected error: ${err.message}`));
+      });
     });
   }
 };


### PR DESCRIPTION
Fixed fs.walkDir to wait until callback completion of last file.

Fix: https://github.com/appium/appium/issues/13515

Note: fix pull request author of https://github.com/appium/appium-support/pull/138