### PR TITLE
build: fix node caching in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,13 @@ node_js:
 addons:
   apt:
     sources:
-      - llvm-toolchain-r-test
+      - ubuntu-toolchain-r-test
     packages:
       - clang-5.0
 cache:
   npm: false
+  directories:
+    - "$(npm root -g)"
 env:
   global:
     - CXX=clang++-5.0
@@ -22,13 +24,17 @@ install:
   # on node 12 opencv4nodejs and mjpeg-consumer cannot be installed
   # also handle possible travis caching
   - if [[ `node --version` != v12* ]]; then
-      printf "while [ true ]; do\nsleep 30\necho 'Building OpenCV'\ndone" > ping.sh;
-      bash ping.sh &
-      echo $! > ping.pid;
-      npm install -g opencv4nodejs > /dev/null 2>&1;
-      kill `cat ping.pid`;
+      if [[ $(npm ls --depth 1 -g opencv4nodejs) =~ "── opencv4nodejs@" ]]; then
+        echo 'Already installed opencv4nodejs';
+      else
+        npm install -g opencv4nodejs;
+      fi
 
-      npm install -g mjpeg-consumer;
+      if [[ $(npm ls --depth 1 -g mjpeg-consumer) =~ "── mjpeg-consumer@" ]]; then
+        echo 'Already have mjpeg-consumer';
+      else
+        npm install -g mjpeg-consumer;
+      fi
     fi
   - npm install
 script:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,7 @@ boilerplate({
     files: [
       './build/test/**/*-specs.js',
       '!./build/test/assets/**',
+      '!./build/test/images/**',
       '!./build/test/**/*-e2e-specs.js'
     ],
     verbose: true,

--- a/lib/node.js
+++ b/lib/node.js
@@ -40,11 +40,11 @@ async function requirePackage (packageName) {
     log.debug(`Loading local package '${packageName}'`);
     return require(packageName);
   } catch (err) {
-    log.debug(`Failed to load package '${packageName}': ${err.message}`);
+    log.debug(`Failed to load local package '${packageName}': ${err.message}`);
     await linkGlobalPackage(packageName);
   }
   try {
-    log.debug(`Retrying load of local package '${packageName}'`);
+    log.debug(`Retrying load of linked package '${packageName}'`);
     return require(packageName);
   } catch (err) {
     log.errorAndThrow(`Unable to load package '${packageName}': ${err.message}`);

--- a/test/fs-specs.js
+++ b/test/fs-specs.js
@@ -5,9 +5,13 @@ import { exec } from 'teen_process';
 import B from 'bluebird';
 
 
-let should = chai.should();
+const should = chai.should();
+
+const MOCHA_TIMEOUT = 10000;
 
 describe('fs', function () {
+  this.timeout(MOCHA_TIMEOUT);
+
   const existingPath = path.resolve(__dirname, 'fs-specs.js');
   it('should exist', function () {
     should.exist(fs);
@@ -155,7 +159,7 @@ describe('fs', function () {
       inCallback.should.equal(0);
       filePath.should.not.be.null;
     });
-    it('walkDir all elements recursive', async function () {
+    it('should walk all elements recursive', async function () {
       let inCallback = 0;
       const filePath = await fs.walkDir(__dirname, true, async () => {
         ++inCallback;

--- a/test/image-util-e2e-specs.js
+++ b/test/image-util-e2e-specs.js
@@ -73,7 +73,7 @@ describe('image-util', function () {
     });
 
     describe('getImagesMatches', function () {
-      it.only('should calculate the number of matches between two images', async function () { // eslint-disable-line
+      it('should calculate the number of matches between two images', async function () {
         for (const detectorName of ['AKAZE', 'ORB']) {
           const {count, totalCount} = await getImagesMatches(fullImage, fullImage, {detectorName});
           count.should.be.above(0);


### PR DESCRIPTION
Re-enable global `node_modules` caching in Travis. Also remove the masking of the install process for `opencv4nodejs` as, in the event of an error in install/build, it makes the problem unclear.