### PR TITLE
feat: add timing API

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,6 @@
 {
-  "extends": "appium"
+  "extends": "appium",
+  "globals": {
+    "BigInt": true
+  }
 }

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ import * as zip from './lib/zip';
 import * as imageUtil from './lib/image-util';
 import * as mjpeg from './lib/mjpeg';
 import * as node from './lib/node';
+import * as timing from './lib/timing';
 
 
 const { fs } = fsIndex;
@@ -19,9 +20,9 @@ const { mkdirp } = mkdirpIndex;
 
 export {
   tempDir, system, util, fs, cancellableDelay, plist, mkdirp, logger, process,
-  zip, imageUtil, net, mjpeg, node,
+  zip, imageUtil, net, mjpeg, node, timing,
 };
 export default {
   tempDir, system, util, fs, cancellableDelay, plist, mkdirp, logger, process,
-  zip, imageUtil, net, mjpeg, node,
+  zip, imageUtil, net, mjpeg, node, timing,
 };

--- a/lib/timing.js
+++ b/lib/timing.js
@@ -1,0 +1,85 @@
+import _ from 'lodash';
+
+
+const DURATION_SECONDS = 's';
+const DURATION_MILLIS = 'ms';
+const DURATION_NANOS = 'ns';
+
+const NS_PER_SEC = 1e9;
+const NS_PER_MS = 1e6;
+
+const CONVERSION_FACTORS = {
+  [DURATION_SECONDS]: NS_PER_SEC,
+  [DURATION_MILLIS]: NS_PER_MS,
+  [DURATION_NANOS]: 1,
+};
+
+/**
+ * Get the start time, to be used when getting the duration
+ *
+ * @return {number|Array<number>} a representation of the start time
+ */
+function getStartTime () {
+  // once Node 10 is no longer supported, this check can be removed
+  if (_.isFunction(process.hrtime.bigint)) {
+    return process.hrtime.bigint();
+  }
+  return process.hrtime();
+}
+
+/**
+ * @typedef {Object} GetDurationOptions
+ *
+ * @property {?string} units - the units to convert to. Can be one of
+ *     - 's' - seconds (default)
+ *     - 'ms' - milliseconds
+ *     - 'ns' - nanoseconds
+ * @property {?boolean} round - whether or not the result should be rounded down
+ */
+
+/**
+ * Get the duration based on a start time
+ *
+ * @param {number|Arrary<number>} startTime - the value returned from calling
+ *     getStartTime`
+ * @param {?string|GetDurationOptions} opts - options for conversion of duration.
+ *     Can be a String representing the units ('s', 'ms', or 'ns') or an Object
+ * @return {number} a number representing the duration, in the specified unit
+ */
+function getDuration (startTime, opts = {}) {
+  if (_.isString(opts)) {
+    opts = {
+      units: opts,
+    };
+  }
+  const {
+    units = DURATION_SECONDS,
+    round = true,
+  } = opts;
+
+  if (!_.keys(CONVERSION_FACTORS).includes(units)) {
+    throw new Error(`Unknown unit for duration conversion: '${units}'`);
+  }
+
+  let nanoDuration;
+  if (_.isArray(startTime)) {
+    // startTime was created using process.hrtime()
+    const [seconds, nanos] = process.hrtime(startTime);
+    nanoDuration = seconds * NS_PER_SEC + nanos;
+  } else if (typeof startTime === 'bigint' && _.isFunction(process.hrtime.bigint)) {
+    // startTime was created using process.hrtime.bigint()
+    const endTime = process.hrtime.bigint();
+    // get the difference, and convert to number
+    nanoDuration = Number(endTime - startTime);
+  } else {
+    throw new Error(`Unable to get duration. Start time '${startTime}' cannot be handled`);
+  }
+
+  const duration = nanoDuration / CONVERSION_FACTORS[units];
+  return round ? Math.round(duration) : duration;
+}
+
+
+export {
+  getStartTime, getDuration, DURATION_MILLIS, DURATION_SECONDS, DURATION_NANOS,
+};

--- a/lib/timing.js
+++ b/lib/timing.js
@@ -1,63 +1,65 @@
 import _ from 'lodash';
 
 
-const DURATION_S = 's';
-const DURATION_MS = 'ms';
-const DURATION_NS = 'ns';
-
-const NS_PER_SEC = 1e9;
+const NS_PER_S = 1e9;
 const NS_PER_MS = 1e6;
-
-const CONVERSION_FACTORS = {
-  [DURATION_S]: NS_PER_SEC,
-  [DURATION_MS]: NS_PER_MS,
-  [DURATION_NS]: 1,
-};
 
 
 /**
  * Class representing a duration, encapsulating the number and units.
  */
 class Duration {
-  constructor (duration, units) {
+  constructor (duration) {
     this._duration = duration;
-    this._units = units;
   }
 
   get duration () {
     return this._duration;
   }
 
-  get units () {
-    return this._units;
+  /**
+   * Get the duration as nanoseconds
+   *
+   * @returns {number} The duration as nanoseconds
+   */
+  get asNanoSeconds () {
+    return this.duration;
+  }
+
+  /**
+   * Get the duration converted into milliseconds
+   *
+   * @returns {number} The duration as milliseconds
+   */
+  get asMilliSeconds () {
+    return this.duration / NS_PER_MS;
+  }
+
+  /**
+   * Get the duration converted into seconds
+   *
+   * @returns {number} The duration fas seconds
+   */
+  get asSeconds () {
+    return this.duration / NS_PER_S;
   }
 
   toString () {
-    return `${this.duration}${this.units}`;
+    // default to milliseconds, rounded
+    return this.asMilliSeconds.toFixed(0);
   }
 }
 
 class Timer {
   /**
    * Creates a timer
-   *
-   * @param {?string} units - the default units for conversion
    */
-  constructor (units = DURATION_MS) {
-    if (!_.keys(CONVERSION_FACTORS).includes(units)) {
-      throw new Error(`Unknown unit for duration conversion: '${units}'. Available units: ${_.keys(CONVERSION_FACTORS).join(', ')}`);
-    }
-
-    this._units = units;
+  constructor () {
     this._startTime = null;
   }
 
   get startTime () {
     return this._startTime;
-  }
-
-  get units () {
-    return this._units;
   }
 
   /**
@@ -77,47 +79,20 @@ class Timer {
   }
 
   /**
-   * @typedef {Object} GetDurationOptions
-   *
-   * @property {?string} units - the units to convert to. Can be one of
-   *     - 's' - seconds (default)
-   *     - 'ms' - milliseconds
-   *     - 'ns' - nanoseconds
-   * @property {?boolean} round - whether or not the result should be rounded to
-   *                              the nearest integer
-   */
-
-  /**
    * Get the duration since the timer was started
    *
-   * @param {?string|GetDurationOptions} opts - options for conversion of duration.
-   *     Can be a String representing the units ('s', 'ms', or 'ns') or an Object
    * @return {Duration} the duration, in the specified units
    */
-  getDuration (opts = {}) {
+  getDuration () {
     if (_.isNull(this.startTime)) {
       throw new Error(`Unable to get duration. Timer was not started`);
-    }
-
-    if (_.isString(opts)) {
-      opts = {
-        units: opts,
-      };
-    }
-    const {
-      units = this.units,
-      round = true,
-    } = opts;
-
-    if (!_.keys(CONVERSION_FACTORS).includes(units)) {
-      throw new Error(`Unknown unit for duration conversion: '${units}'. Available units: ${_.keys(CONVERSION_FACTORS).join(', ')}`);
     }
 
     let nanoDuration;
     if (_.isArray(this.startTime)) {
       // startTime was created using process.hrtime()
       const [seconds, nanos] = process.hrtime(this.startTime);
-      nanoDuration = seconds * NS_PER_SEC + nanos;
+      nanoDuration = seconds * NS_PER_S + nanos;
     } else if (typeof this.startTime === 'bigint' && _.isFunction(process.hrtime.bigint)) {
       // startTime was created using process.hrtime.bigint()
       const endTime = process.hrtime.bigint();
@@ -127,18 +102,18 @@ class Timer {
       throw new Error(`Unable to get duration. Start time '${this.startTime}' cannot be parsed`);
     }
 
-    const duration = nanoDuration / CONVERSION_FACTORS[units];
-    return new Duration(round ? Math.round(duration) : duration, units);
+    return new Duration(nanoDuration);
   }
 
   toString () {
-    return this.getDuration().toString();
+    try {
+      return this.getDuration().toString();
+    } catch (err) {
+      return `<err: ${err.message}>`;
+    }
   }
 }
 
 
-export {
-  Timer, Duration,
-  DURATION_S, DURATION_MS, DURATION_NS,
-};
+export { Timer, Duration };
 export default Timer;

--- a/lib/timing.js
+++ b/lib/timing.js
@@ -81,7 +81,7 @@ class Timer {
   /**
    * Get the duration since the timer was started
    *
-   * @return {Duration} the duration, in the specified units
+   * @return {Duration} the duration
    */
   getDuration () {
     if (_.isNull(this.startTime)) {

--- a/lib/timing.js
+++ b/lib/timing.js
@@ -15,22 +15,48 @@ const CONVERSION_FACTORS = {
 };
 
 
+class Duration {
+  constructor (duration, units) {
+    this._duration = duration;
+    this._units = units;
+  }
+
+  get duration () {
+    return this._duration;
+  }
+
+  get units () {
+    return this._units;
+  }
+
+  toString () {
+    return `${this.duration}${this.units}`;
+  }
+}
+
 class Timer {
-  constructor (autoStart = false) {
-    this.startTime = autoStart ? this.start() : null;
+  constructor () {
+    this._startTime = null;
+  }
+
+  get startTime () {
+    return this._startTime;
   }
 
   /**
    * Start the timer
    *
-   * @return {number|Array<number>} a representation of the start time
+   * @return {Timer} The current instance, for chaining
    */
   start () {
+    if (!_.isNull(this.startTime)) {
+      throw new Error('Timer has already been started.');
+    }
     // once Node 10 is no longer supported, this check can be removed
-    this.startTime = _.isFunction(process.hrtime.bigint)
+    this._startTime = _.isFunction(process.hrtime.bigint)
       ? process.hrtime.bigint()
       : process.hrtime();
-    return this.startTime;
+    return this;
   }
 
   /**
@@ -40,7 +66,8 @@ class Timer {
    *     - 's' - seconds (default)
    *     - 'ms' - milliseconds
    *     - 'ns' - nanoseconds
-   * @property {?boolean} round - whether or not the result should be rounded down
+   * @property {?boolean} round - whether or not the result should be rounded to
+   *                              the nearest integer
    */
 
   /**
@@ -48,7 +75,7 @@ class Timer {
    *
    * @param {?string|GetDurationOptions} opts - options for conversion of duration.
    *     Can be a String representing the units ('s', 'ms', or 'ns') or an Object
-   * @return {number} a number representing the duration, in the specified unit
+   * @return {Duration} the duration, in the specified unit
    */
   getDuration (opts = {}) {
     if (_.isNull(this.startTime)) {
@@ -66,7 +93,7 @@ class Timer {
     } = opts;
 
     if (!_.keys(CONVERSION_FACTORS).includes(units)) {
-      throw new Error(`Unknown unit for duration conversion: '${units}'`);
+      throw new Error(`Unknown unit for duration conversion: '${units}'. Available units: ${_.keys(CONVERSION_FACTORS).join(', ')}`);
     }
 
     let nanoDuration;
@@ -84,12 +111,13 @@ class Timer {
     }
 
     const duration = nanoDuration / CONVERSION_FACTORS[units];
-    return round ? Math.round(duration) : duration;
+    return new Duration(round ? Math.round(duration) : duration, units);
   }
 }
 
 
 export {
-  Timer, DURATION_MILLIS, DURATION_SECONDS, DURATION_NANOS,
+  Timer, Duration,
+  DURATION_MILLIS, DURATION_SECONDS, DURATION_NANOS,
 };
 export default Timer;

--- a/lib/timing.js
+++ b/lib/timing.js
@@ -38,12 +38,26 @@ class Duration {
 }
 
 class Timer {
-  constructor () {
+  /**
+   * Creates a timer
+   *
+   * @param {?string} units - the default units for conversion
+   */
+  constructor (units = DURATION_MS) {
+    if (!_.keys(CONVERSION_FACTORS).includes(units)) {
+      throw new Error(`Unknown unit for duration conversion: '${units}'. Available units: ${_.keys(CONVERSION_FACTORS).join(', ')}`);
+    }
+
+    this._units = units;
     this._startTime = null;
   }
 
   get startTime () {
     return this._startTime;
+  }
+
+  get units () {
+    return this._units;
   }
 
   /**
@@ -91,7 +105,7 @@ class Timer {
       };
     }
     const {
-      units = DURATION_MS,
+      units = this.units,
       round = true,
     } = opts;
 
@@ -115,6 +129,10 @@ class Timer {
 
     const duration = nanoDuration / CONVERSION_FACTORS[units];
     return new Duration(round ? Math.round(duration) : duration, units);
+  }
+
+  toString () {
+    return this.getDuration().toString();
   }
 }
 

--- a/lib/timing.js
+++ b/lib/timing.js
@@ -1,17 +1,17 @@
 import _ from 'lodash';
 
 
-const DURATION_SECONDS = 's';
-const DURATION_MILLIS = 'ms';
-const DURATION_NANOS = 'ns';
+const DURATION_S = 's';
+const DURATION_MS = 'ms';
+const DURATION_NS = 'ns';
 
 const NS_PER_SEC = 1e9;
 const NS_PER_MS = 1e6;
 
 const CONVERSION_FACTORS = {
-  [DURATION_SECONDS]: NS_PER_SEC,
-  [DURATION_MILLIS]: NS_PER_MS,
-  [DURATION_NANOS]: 1,
+  [DURATION_S]: NS_PER_SEC,
+  [DURATION_MS]: NS_PER_MS,
+  [DURATION_NS]: 1,
 };
 
 
@@ -91,7 +91,7 @@ class Timer {
       };
     }
     const {
-      units = DURATION_SECONDS,
+      units = DURATION_MS,
       round = true,
     } = opts;
 
@@ -121,6 +121,6 @@ class Timer {
 
 export {
   Timer, Duration,
-  DURATION_MILLIS, DURATION_SECONDS, DURATION_NANOS,
+  DURATION_S, DURATION_MS, DURATION_NS,
 };
 export default Timer;

--- a/lib/timing.js
+++ b/lib/timing.js
@@ -9,12 +9,12 @@ const NS_PER_MS = 1e6;
  * Class representing a duration, encapsulating the number and units.
  */
 class Duration {
-  constructor (duration) {
-    this._duration = duration;
+  constructor (nanos) {
+    this._nanos = nanos;
   }
 
-  get duration () {
-    return this._duration;
+  get nanos () {
+    return this._nanos;
   }
 
   /**
@@ -23,7 +23,7 @@ class Duration {
    * @returns {number} The duration as nanoseconds
    */
   get asNanoSeconds () {
-    return this.duration;
+    return this.nanos;
   }
 
   /**
@@ -32,7 +32,7 @@ class Duration {
    * @returns {number} The duration as milliseconds
    */
   get asMilliSeconds () {
-    return this.duration / NS_PER_MS;
+    return this.nanos / NS_PER_MS;
   }
 
   /**
@@ -41,7 +41,7 @@ class Duration {
    * @returns {number} The duration fas seconds
    */
   get asSeconds () {
-    return this.duration / NS_PER_S;
+    return this.nanos / NS_PER_S;
   }
 
   toString () {

--- a/lib/timing.js
+++ b/lib/timing.js
@@ -15,6 +15,9 @@ const CONVERSION_FACTORS = {
 };
 
 
+/**
+ * Class representing a duration, encapsulating the number and units.
+ */
 class Duration {
   constructor (duration, units) {
     this._duration = duration;
@@ -75,7 +78,7 @@ class Timer {
    *
    * @param {?string|GetDurationOptions} opts - options for conversion of duration.
    *     Can be a String representing the units ('s', 'ms', or 'ns') or an Object
-   * @return {Duration} the duration, in the specified unit
+   * @return {Duration} the duration, in the specified units
    */
   getDuration (opts = {}) {
     if (_.isNull(this.startTime)) {

--- a/lib/timing.js
+++ b/lib/timing.js
@@ -14,72 +14,82 @@ const CONVERSION_FACTORS = {
   [DURATION_NANOS]: 1,
 };
 
-/**
- * Get the start time, to be used when getting the duration
- *
- * @return {number|Array<number>} a representation of the start time
- */
-function getStartTime () {
-  // once Node 10 is no longer supported, this check can be removed
-  if (_.isFunction(process.hrtime.bigint)) {
-    return process.hrtime.bigint();
-  }
-  return process.hrtime();
-}
 
-/**
- * @typedef {Object} GetDurationOptions
- *
- * @property {?string} units - the units to convert to. Can be one of
- *     - 's' - seconds (default)
- *     - 'ms' - milliseconds
- *     - 'ns' - nanoseconds
- * @property {?boolean} round - whether or not the result should be rounded down
- */
-
-/**
- * Get the duration based on a start time
- *
- * @param {number|Arrary<number>} startTime - the value returned from calling
- *     getStartTime`
- * @param {?string|GetDurationOptions} opts - options for conversion of duration.
- *     Can be a String representing the units ('s', 'ms', or 'ns') or an Object
- * @return {number} a number representing the duration, in the specified unit
- */
-function getDuration (startTime, opts = {}) {
-  if (_.isString(opts)) {
-    opts = {
-      units: opts,
-    };
-  }
-  const {
-    units = DURATION_SECONDS,
-    round = true,
-  } = opts;
-
-  if (!_.keys(CONVERSION_FACTORS).includes(units)) {
-    throw new Error(`Unknown unit for duration conversion: '${units}'`);
+class Timer {
+  constructor (autoStart = false) {
+    this.startTime = autoStart ? this.start() : null;
   }
 
-  let nanoDuration;
-  if (_.isArray(startTime)) {
-    // startTime was created using process.hrtime()
-    const [seconds, nanos] = process.hrtime(startTime);
-    nanoDuration = seconds * NS_PER_SEC + nanos;
-  } else if (typeof startTime === 'bigint' && _.isFunction(process.hrtime.bigint)) {
-    // startTime was created using process.hrtime.bigint()
-    const endTime = process.hrtime.bigint();
-    // get the difference, and convert to number
-    nanoDuration = Number(endTime - startTime);
-  } else {
-    throw new Error(`Unable to get duration. Start time '${startTime}' cannot be handled`);
+  /**
+   * Start the timer
+   *
+   * @return {number|Array<number>} a representation of the start time
+   */
+  start () {
+    // once Node 10 is no longer supported, this check can be removed
+    this.startTime = _.isFunction(process.hrtime.bigint)
+      ? process.hrtime.bigint()
+      : process.hrtime();
+    return this.startTime;
   }
 
-  const duration = nanoDuration / CONVERSION_FACTORS[units];
-  return round ? Math.round(duration) : duration;
+  /**
+   * @typedef {Object} GetDurationOptions
+   *
+   * @property {?string} units - the units to convert to. Can be one of
+   *     - 's' - seconds (default)
+   *     - 'ms' - milliseconds
+   *     - 'ns' - nanoseconds
+   * @property {?boolean} round - whether or not the result should be rounded down
+   */
+
+  /**
+   * Get the duration since the timer was started
+   *
+   * @param {?string|GetDurationOptions} opts - options for conversion of duration.
+   *     Can be a String representing the units ('s', 'ms', or 'ns') or an Object
+   * @return {number} a number representing the duration, in the specified unit
+   */
+  getDuration (opts = {}) {
+    if (_.isNull(this.startTime)) {
+      throw new Error(`Unable to get duration. Timer was not started`);
+    }
+
+    if (_.isString(opts)) {
+      opts = {
+        units: opts,
+      };
+    }
+    const {
+      units = DURATION_SECONDS,
+      round = true,
+    } = opts;
+
+    if (!_.keys(CONVERSION_FACTORS).includes(units)) {
+      throw new Error(`Unknown unit for duration conversion: '${units}'`);
+    }
+
+    let nanoDuration;
+    if (_.isArray(this.startTime)) {
+      // startTime was created using process.hrtime()
+      const [seconds, nanos] = process.hrtime(this.startTime);
+      nanoDuration = seconds * NS_PER_SEC + nanos;
+    } else if (typeof this.startTime === 'bigint' && _.isFunction(process.hrtime.bigint)) {
+      // startTime was created using process.hrtime.bigint()
+      const endTime = process.hrtime.bigint();
+      // get the difference, and convert to number
+      nanoDuration = Number(endTime - this.startTime);
+    } else {
+      throw new Error(`Unable to get duration. Start time '${this.startTime}' cannot be parsed`);
+    }
+
+    const duration = nanoDuration / CONVERSION_FACTORS[units];
+    return round ? Math.round(duration) : duration;
+  }
 }
 
 
 export {
-  getStartTime, getDuration, DURATION_MILLIS, DURATION_SECONDS, DURATION_NANOS,
+  Timer, DURATION_MILLIS, DURATION_SECONDS, DURATION_NANOS,
 };
+export default Timer;

--- a/test/fs-specs.js
+++ b/test/fs-specs.js
@@ -7,7 +7,7 @@ import B from 'bluebird';
 
 const should = chai.should();
 
-const MOCHA_TIMEOUT = 10000;
+const MOCHA_TIMEOUT = 20000;
 
 describe('fs', function () {
   this.timeout(MOCHA_TIMEOUT);

--- a/test/timing-specs.js
+++ b/test/timing-specs.js
@@ -1,0 +1,169 @@
+import _ from 'lodash';
+import chai from 'chai';
+import sinon from 'sinon';
+import { timing } from '..';
+
+
+chai.should();
+const expect = chai.expect;
+
+describe.only('timing', function () { // eslint-disable-line
+  let processMock;
+  afterEach(function () {
+    processMock.verify();
+  });
+
+  describe('no bigint', function () {
+    const bigintFn = process.hrtime.bigint;
+    before(function () {
+      // if the system has BigInt support, remove it
+      if (_.isFunction(bigintFn)) {
+        delete process.hrtime.bigint;
+      }
+    });
+    beforeEach(function () {
+      processMock = sinon.mock(process);
+    });
+    after(function () {
+      if (_.isFunction(bigintFn)) {
+        process.hrtime.bigint = bigintFn;
+      }
+    });
+    it('should get a start time as array', function () {
+      const startTime = timing.getStartTime();
+      _.isArray(startTime).should.be.true;
+    });
+    it('should get a duration', function () {
+      const startTime = timing.getStartTime();
+      const duration = timing.getDuration(startTime);
+      _.isNumber(duration).should.be.true;
+    });
+    it('should get correct s', function () {
+      processMock.expects('hrtime').twice()
+        .onFirstCall().returns([12, 12345])
+        .onSecondCall().returns([13, 54321]);
+
+      const startTime = timing.getStartTime();
+      const duration = timing.getDuration(startTime, {
+        units: timing.DURATION_SECONDS,
+        round: false,
+      });
+      duration.should.eql(13.000054321);
+    });
+    it('should get correct s rounded', function () {
+      processMock.expects('hrtime').twice()
+        .onFirstCall().returns([12, 12345])
+        .onSecondCall().returns([13, 54321]);
+
+      const startTime = timing.getStartTime();
+      const duration = timing.getDuration(startTime, {
+        units: timing.DURATION_SECONDS,
+      });
+      duration.should.eql(13);
+    });
+    it('should get correct ms', function () {
+      processMock.expects('hrtime').twice()
+        .onFirstCall().returns([12, 12345])
+        .onSecondCall().returns([13, 54321]);
+
+      const startTime = timing.getStartTime();
+      const duration = timing.getDuration(startTime, {
+        units: timing.DURATION_MILLIS,
+        round: false,
+      });
+      duration.should.eql(13000.054321);
+    });
+    it('should get correct ns', function () {
+      processMock.expects('hrtime').twice()
+        .onFirstCall().returns([12, 12345])
+        .onSecondCall().returns([13, 54321]);
+
+      const startTime = timing.getStartTime();
+      const duration = timing.getDuration(startTime, {
+        units: timing.DURATION_NANOS,
+        round: false,
+      });
+      duration.should.eql(13000054321);
+    });
+    it('should error if passing in a number', function () {
+      expect(() => timing.getDuration(12345))
+        .to.throw('Unable to get duration');
+    });
+    it('should error if passing in wrong unit', function () {
+      const startTime = timing.getStartTime();
+      expect(() => timing.getDuration(startTime, 'ds'))
+        .to.throw('Unknown unit for duration');
+    });
+  });
+  describe('bigint', function () {
+    beforeEach(function () {
+      processMock = sinon.mock(process.hrtime);
+    });
+    it('should get a start time as number', function () {
+      // the non-mocked test cannot run if the function doesn't exist
+      if (!_.isFunction(process.hrtime.bigint)) {
+        return this.skip();
+      }
+
+      const startTime = timing.getStartTime();
+      const duration = timing.getDuration(startTime);
+      _.isNumber(duration).should.be.true;
+    });
+    it('should get correct s', function () {
+      processMock.expects('bigint').twice()
+        .onFirstCall().returns(BigInt(1172941153404030))
+        .onSecondCall().returns(BigInt(1172951164887132));
+
+      const startTime = timing.getStartTime();
+      const duration = timing.getDuration(startTime, {
+        units: timing.DURATION_SECONDS,
+        round: false,
+      });
+      duration.should.be.eql(10.011483102);
+    });
+    it('should get correct s rounded', function () {
+      processMock.expects('bigint').twice()
+        .onFirstCall().returns(BigInt(1172941153404030))
+        .onSecondCall().returns(BigInt(1172951164887132));
+
+      const startTime = timing.getStartTime();
+      const duration = timing.getDuration(startTime, {
+        units: timing.DURATION_SECONDS,
+      });
+      duration.should.be.eql(10);
+    });
+    it('should get correct ms', function () {
+      processMock.expects('bigint').twice()
+        .onFirstCall().returns(BigInt(1172941153404030))
+        .onSecondCall().returns(BigInt(1172951164887132));
+
+      const startTime = timing.getStartTime();
+      const duration = timing.getDuration(startTime, {
+        units: timing.DURATION_MILLIS,
+        round: false,
+      });
+      duration.should.be.eql(10011.483102);
+    });
+    it('should get correct ns', function () {
+      processMock.expects('bigint').twice()
+        .onFirstCall().returns(BigInt(1172941153404030))
+        .onSecondCall().returns(BigInt(1172951164887132));
+
+      const startTime = timing.getStartTime();
+      const duration = timing.getDuration(startTime, {
+        units: timing.DURATION_NANOS,
+        round: false,
+      });
+      duration.should.be.eql(10011483102);
+    });
+    it('should error if passing in a non-bigint', function () {
+      expect(() => timing.getDuration(12345))
+        .to.throw('Unable to get duration');
+    });
+    it('should error if passing in wrong unit', function () {
+      const startTime = timing.getStartTime();
+      expect(() => timing.getDuration(startTime, 'ds'))
+        .to.throw('Unknown unit for duration');
+    });
+  });
+});

--- a/test/timing-specs.js
+++ b/test/timing-specs.js
@@ -30,70 +30,65 @@ describe('timing', function () {
       }
     });
     it('should get a start time as array', function () {
-      const timer = new timing.Timer();
-      timer.start();
-      _.isArray(timer.startTime).should.be.true;
-    });
-    it('should auto start when requested', function () {
-      const timer = new timing.Timer(true);
+      const timer = new timing.Timer().start();
       _.isArray(timer.startTime).should.be.true;
     });
     it('should get a duration', function () {
-      const timer = new timing.Timer();
-      timer.start();
+      const timer = new timing.Timer().start();
       const duration = timer.getDuration();
-      _.isNumber(duration).should.be.true;
+      _.isNumber(duration.duration).should.be.true;
+      _.isString(duration.units).should.be.true;
     });
     it('should get correct s', function () {
       processMock.expects('hrtime').twice()
         .onFirstCall().returns([12, 12345])
         .onSecondCall().returns([13, 54321]);
 
-      const timer = new timing.Timer();
-      timer.start();
+      const timer = new timing.Timer().start();
       const duration = timer.getDuration({
         units: timing.DURATION_SECONDS,
         round: false,
       });
-      duration.should.eql(13.000054321);
+      duration.duration.should.eql(13.000054321);
+      duration.units.should.eql('s');
     });
     it('should get correct s rounded', function () {
       processMock.expects('hrtime').twice()
         .onFirstCall().returns([12, 12345])
         .onSecondCall().returns([13, 54321]);
 
-      const timer = new timing.Timer();
-      timer.start();
+      const timer = new timing.Timer().start();
       const duration = timer.getDuration({
         units: timing.DURATION_SECONDS,
       });
-      duration.should.eql(13);
+      duration.duration.should.eql(13);
+      duration.units.should.eql('s');
     });
     it('should get correct ms', function () {
       processMock.expects('hrtime').twice()
         .onFirstCall().returns([12, 12345])
         .onSecondCall().returns([13, 54321]);
 
-      const timer = new timing.Timer();
-      timer.start();
+      const timer = new timing.Timer().start();
       const duration = timer.getDuration({
         units: timing.DURATION_MILLIS,
         round: false,
       });
-      duration.should.eql(13000.054321);
+      duration.duration.should.eql(13000.054321);
+      duration.units.should.eql('ms');
     });
     it('should get correct ns', function () {
       processMock.expects('hrtime').twice()
         .onFirstCall().returns([12, 12345])
         .onSecondCall().returns([13, 54321]);
 
-      const timer = new timing.Timer();
-      timer.start();
+      const timer = new timing.Timer().start();
       const duration = timer.getDuration({
         units: timing.DURATION_NANOS,
         round: false,
       });
-      duration.should.eql(13000054321);
+      duration.duration.should.eql(13000054321);
+      duration.units.should.eql('ns');
     });
     it('should error if the timer was not started', function () {
       const timer = new timing.Timer();
@@ -102,13 +97,12 @@ describe('timing', function () {
     });
     it('should error if start time is a number', function () {
       const timer = new timing.Timer();
-      timer.startTime = 12345;
+      timer._startTime = 12345;
       expect(() => timer.getDuration())
         .to.throw('Unable to get duration');
     });
     it('should error if passing in wrong unit', function () {
-      const timer = new timing.Timer();
-      timer.start();
+      const timer = new timing.Timer().start();
       expect(() => timer.getDuration('ds'))
         .to.throw('Unknown unit for duration');
     });
@@ -136,56 +130,55 @@ describe('timing', function () {
       }
     }
 
-    it('should get a start time as number', function () {
+    it('should get a duration', function () {
       setupMocks();
 
-      const timer = new timing.Timer();
-      timer.start();
+      const timer = new timing.Timer().start();
       const duration = timer.getDuration();
-      _.isNumber(duration).should.be.true;
+      _.isNumber(duration.duration).should.be.true;
     });
     it('should get correct s', function () {
       setupMocks();
 
-      const timer = new timing.Timer();
-      timer.start();
+      const timer = new timing.Timer().start();
       const duration = timer.getDuration({
         units: timing.DURATION_SECONDS,
         round: false,
       });
-      duration.should.be.eql(10.011483102);
+      duration.duration.should.be.eql(10.011483102);
+      duration.units.should.eql('s');
     });
     it('should get correct s rounded', function () {
       setupMocks();
 
-      const timer = new timing.Timer();
-      timer.start();
+      const timer = new timing.Timer().start();
       const duration = timer.getDuration({
         units: timing.DURATION_SECONDS,
       });
-      duration.should.be.eql(10);
+      duration.duration.should.be.eql(10);
+      duration.units.should.eql('s');
     });
     it('should get correct ms', function () {
       setupMocks();
 
-      const timer = new timing.Timer();
-      timer.start();
+      const timer = new timing.Timer().start();
       const duration = timer.getDuration({
         units: timing.DURATION_MILLIS,
         round: false,
       });
-      duration.should.be.eql(10011.483102);
+      duration.duration.should.be.eql(10011.483102);
+      duration.units.should.eql('ms');
     });
     it('should get correct ns', function () {
       setupMocks();
 
-      const timer = new timing.Timer();
-      timer.start();
+      const timer = new timing.Timer().start();
       const duration = timer.getDuration({
         units: timing.DURATION_NANOS,
         round: false,
       });
-      duration.should.be.eql(10011483102);
+      duration.duration.should.be.eql(10011483102);
+      duration.units.should.eql('ns');
     });
     it('should error if the timer was not started', function () {
       const timer = new timing.Timer();
@@ -194,15 +187,14 @@ describe('timing', function () {
     });
     it('should error if passing in a non-bigint', function () {
       const timer = new timing.Timer();
-      timer.startTime = 12345;
+      timer._startTime = 12345;
       expect(() => timer.getDuration())
         .to.throw('Unable to get duration');
     });
     it('should error if passing in wrong unit', function () {
       setupMocks(true);
 
-      const timer = new timing.Timer();
-      timer.start();
+      const timer = new timing.Timer().start();
       expect(() => timer.getDuration('ds'))
         .to.throw('Unknown unit for duration');
     });

--- a/test/timing-specs.js
+++ b/test/timing-specs.js
@@ -36,7 +36,7 @@ describe('timing', function () {
     it('should get a duration', function () {
       const timer = new timing.Timer().start();
       const duration = timer.getDuration();
-      _.isNumber(duration.duration).should.be.true;
+      _.isNumber(duration.nanos).should.be.true;
     });
     it('should get correct seconds', function () {
       processMock.expects('hrtime').twice()
@@ -105,7 +105,7 @@ describe('timing', function () {
 
       const timer = new timing.Timer().start();
       const duration = timer.getDuration();
-      _.isNumber(duration.duration).should.be.true;
+      _.isNumber(duration.nanos).should.be.true;
     });
     it('should get correct seconds', function () {
       setupMocks();

--- a/test/timing-specs.js
+++ b/test/timing-specs.js
@@ -46,7 +46,7 @@ describe('timing', function () {
 
       const timer = new timing.Timer().start();
       const duration = timer.getDuration({
-        units: timing.DURATION_SECONDS,
+        units: timing.DURATION_S,
         round: false,
       });
       duration.duration.should.eql(13.000054321);
@@ -59,7 +59,7 @@ describe('timing', function () {
 
       const timer = new timing.Timer().start();
       const duration = timer.getDuration({
-        units: timing.DURATION_SECONDS,
+        units: timing.DURATION_S,
       });
       duration.duration.should.eql(13);
       duration.units.should.eql('s');
@@ -71,7 +71,7 @@ describe('timing', function () {
 
       const timer = new timing.Timer().start();
       const duration = timer.getDuration({
-        units: timing.DURATION_MILLIS,
+        units: timing.DURATION_MS,
         round: false,
       });
       duration.duration.should.eql(13000.054321);
@@ -84,7 +84,7 @@ describe('timing', function () {
 
       const timer = new timing.Timer().start();
       const duration = timer.getDuration({
-        units: timing.DURATION_NANOS,
+        units: timing.DURATION_NS,
         round: false,
       });
       duration.duration.should.eql(13000054321);
@@ -142,7 +142,7 @@ describe('timing', function () {
 
       const timer = new timing.Timer().start();
       const duration = timer.getDuration({
-        units: timing.DURATION_SECONDS,
+        units: timing.DURATION_S,
         round: false,
       });
       duration.duration.should.be.eql(10.011483102);
@@ -153,7 +153,7 @@ describe('timing', function () {
 
       const timer = new timing.Timer().start();
       const duration = timer.getDuration({
-        units: timing.DURATION_SECONDS,
+        units: timing.DURATION_S,
       });
       duration.duration.should.be.eql(10);
       duration.units.should.eql('s');
@@ -163,7 +163,7 @@ describe('timing', function () {
 
       const timer = new timing.Timer().start();
       const duration = timer.getDuration({
-        units: timing.DURATION_MILLIS,
+        units: timing.DURATION_MS,
         round: false,
       });
       duration.duration.should.be.eql(10011.483102);
@@ -174,7 +174,7 @@ describe('timing', function () {
 
       const timer = new timing.Timer().start();
       const duration = timer.getDuration({
-        units: timing.DURATION_NANOS,
+        units: timing.DURATION_NS,
         round: false,
       });
       duration.duration.should.be.eql(10011483102);

--- a/test/timing-specs.js
+++ b/test/timing-specs.js
@@ -37,58 +37,33 @@ describe('timing', function () {
       const timer = new timing.Timer().start();
       const duration = timer.getDuration();
       _.isNumber(duration.duration).should.be.true;
-      _.isString(duration.units).should.be.true;
     });
-    it('should get correct s', function () {
+    it('should get correct seconds', function () {
       processMock.expects('hrtime').twice()
         .onFirstCall().returns([12, 12345])
         .onSecondCall().returns([13, 54321]);
 
       const timer = new timing.Timer().start();
-      const duration = timer.getDuration({
-        units: timing.DURATION_S,
-        round: false,
-      });
-      duration.duration.should.eql(13.000054321);
-      duration.units.should.eql('s');
+      const duration = timer.getDuration();
+      duration.asSeconds.should.eql(13.000054321);
     });
-    it('should get correct s rounded', function () {
+    it('should get correct milliseconds', function () {
       processMock.expects('hrtime').twice()
         .onFirstCall().returns([12, 12345])
         .onSecondCall().returns([13, 54321]);
 
       const timer = new timing.Timer().start();
-      const duration = timer.getDuration({
-        units: timing.DURATION_S,
-      });
-      duration.duration.should.eql(13);
-      duration.units.should.eql('s');
+      const duration = timer.getDuration();
+      duration.asMilliSeconds.should.eql(13000.054321);
     });
-    it('should get correct ms', function () {
+    it('should get correct nanoseconds', function () {
       processMock.expects('hrtime').twice()
         .onFirstCall().returns([12, 12345])
         .onSecondCall().returns([13, 54321]);
 
       const timer = new timing.Timer().start();
-      const duration = timer.getDuration({
-        units: timing.DURATION_MS,
-        round: false,
-      });
-      duration.duration.should.eql(13000.054321);
-      duration.units.should.eql('ms');
-    });
-    it('should get correct ns', function () {
-      processMock.expects('hrtime').twice()
-        .onFirstCall().returns([12, 12345])
-        .onSecondCall().returns([13, 54321]);
-
-      const timer = new timing.Timer().start();
-      const duration = timer.getDuration({
-        units: timing.DURATION_NS,
-        round: false,
-      });
-      duration.duration.should.eql(13000054321);
-      duration.units.should.eql('ns');
+      const duration = timer.getDuration();
+      duration.asNanoSeconds.should.eql(13000054321);
     });
     it('should error if the timer was not started', function () {
       const timer = new timing.Timer();
@@ -100,11 +75,6 @@ describe('timing', function () {
       timer._startTime = 12345;
       expect(() => timer.getDuration())
         .to.throw('Unable to get duration');
-    });
-    it('should error if passing in wrong unit', function () {
-      const timer = new timing.Timer().start();
-      expect(() => timer.getDuration('ds'))
-        .to.throw('Unknown unit for duration');
     });
   });
   describe('bigint', function () {
@@ -137,48 +107,26 @@ describe('timing', function () {
       const duration = timer.getDuration();
       _.isNumber(duration.duration).should.be.true;
     });
-    it('should get correct s', function () {
+    it('should get correct seconds', function () {
       setupMocks();
 
       const timer = new timing.Timer().start();
-      const duration = timer.getDuration({
-        units: timing.DURATION_S,
-        round: false,
-      });
-      duration.duration.should.be.eql(10.011483102);
-      duration.units.should.eql('s');
+      const duration = timer.getDuration();
+      duration.asSeconds.should.be.eql(10.011483102);
     });
-    it('should get correct s rounded', function () {
+    it('should get correct milliseconds', function () {
       setupMocks();
 
       const timer = new timing.Timer().start();
-      const duration = timer.getDuration({
-        units: timing.DURATION_S,
-      });
-      duration.duration.should.be.eql(10);
-      duration.units.should.eql('s');
+      const duration = timer.getDuration();
+      duration.asMilliSeconds.should.be.eql(10011.483102);
     });
-    it('should get correct ms', function () {
+    it('should get correct nanoseconds', function () {
       setupMocks();
 
       const timer = new timing.Timer().start();
-      const duration = timer.getDuration({
-        units: timing.DURATION_MS,
-        round: false,
-      });
-      duration.duration.should.be.eql(10011.483102);
-      duration.units.should.eql('ms');
-    });
-    it('should get correct ns', function () {
-      setupMocks();
-
-      const timer = new timing.Timer().start();
-      const duration = timer.getDuration({
-        units: timing.DURATION_NS,
-        round: false,
-      });
-      duration.duration.should.be.eql(10011483102);
-      duration.units.should.eql('ns');
+      const duration = timer.getDuration();
+      duration.asNanoSeconds.should.be.eql(10011483102);
     });
     it('should error if the timer was not started', function () {
       const timer = new timing.Timer();
@@ -190,13 +138,6 @@ describe('timing', function () {
       timer._startTime = 12345;
       expect(() => timer.getDuration())
         .to.throw('Unable to get duration');
-    });
-    it('should error if passing in wrong unit', function () {
-      setupMocks(true);
-
-      const timer = new timing.Timer().start();
-      expect(() => timer.getDuration('ds'))
-        .to.throw('Unknown unit for duration');
     });
   });
 });


### PR DESCRIPTION
We have a number of different mechanisms for getting the duration of operations. This is a first pass at making an extensible API for our use. Once the Performance API is out of super-experimental in Node, this could encapsulate that too, without needing application code to be messed with.