### PR TITLE
fix: make things run on Node < 10.5

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -6,9 +6,8 @@ import fs from './fs';
 import semver from 'semver';
 import { quote as shellQuote } from 'shell-quote';
 
-const W3C_WEB_ELEMENT_IDENTIFIER = 'element-6066-11e4-a52e-4f735466cecf';
 
-const NODE_VERSION = semver.coerce(process.version);
+const W3C_WEB_ELEMENT_IDENTIFIER = 'element-6066-11e4-a52e-4f735466cecf';
 
 export function hasContent (val) {
   return _.isString(val) && val !== '';
@@ -266,7 +265,7 @@ async function isSameDestination (path1, path2, ...pathN) {
   let mapCb = async (x) => await fs.stat(x, {
     bigint: true,
   }).ino;
-  if (NODE_VERSION.major <= 10 && NODE_VERSION.minor < 5) {
+  if (semver.lt(process.version, '10.5.0')) {
     mapCb = async (x) => await fs.stat(x).ino;
   }
   return areAllItemsEqual(await B.map(allPaths, mapCb));

--- a/lib/util.js
+++ b/lib/util.js
@@ -8,6 +8,8 @@ import { quote as shellQuote } from 'shell-quote';
 
 const W3C_WEB_ELEMENT_IDENTIFIER = 'element-6066-11e4-a52e-4f735466cecf';
 
+const NODE_VERSION = semver.coerce(process.version);
+
 export function hasContent (val) {
   return _.isString(val) && val !== '';
 }
@@ -257,9 +259,17 @@ async function isSameDestination (path1, path2, ...pathN) {
   if (areAllItemsEqual(allPaths)) {
     return true;
   }
-  return areAllItemsEqual(await B.map(allPaths, async (x) => (await fs.stat(x, {
-    bigint: true
-  })).ino));
+
+  // Node 10.5.0 introduced bigint support in stat, which allows for more precision
+  // however below that the options get interpreted as the callback
+  // TODO: remove when Node 10 is no longer supported
+  let mapCb = async (x) => await fs.stat(x, {
+    bigint: true,
+  }).ino;
+  if (NODE_VERSION.major <= 10 && NODE_VERSION.minor < 5) {
+    mapCb = async (x) => await fs.stat(x).ino;
+  }
+  return areAllItemsEqual(await B.map(allPaths, mapCb));
 }
 
 /**


### PR DESCRIPTION
We use the `bigint` option for `fs.stat`, but below Node 10.5.0 the options are interpreted as the callback, which fails. Until we no longer support Node 10, this needs to be properly handled.