### PR TITLE
refactor: more visibility into walking the directories

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -9,7 +9,9 @@ import which from 'which';
 import glob from 'glob';
 import crypto from 'crypto';
 import klaw from 'klaw';
+import pluralize from 'pluralize';
 import log from './logger';
+import Timer from './timing';
 
 
 const md5 = B.promisify(md5file);
@@ -86,13 +88,24 @@ let fs = {
       throw Error(`'${dir}' is not a valid root directory` + (errMsg ? `. Original error: ${errMsg}` : ''));
     }
 
-    let lastFileProcessed = B.resolve();
     return await new B((resolve, reject) => {
+      let lastFileProcessed = B.resolve();
+      let fileCount = 0;
+      let directoryCount = 0;
+      const timer = new Timer().start();
+
       const walker = klaw(dir, {
-        depthLimit: recursive ? -1 : 0
+        depthLimit: recursive ? -1 : 0,
       });
-      walker.on('data', (item) => {
+      walker.on('data', function (item) {
         walker.pause();
+
+        if (!item.stats.isDirectory()) {
+          fileCount++;
+        } else {
+          directoryCount++;
+        }
+
         // eslint-disable-next-line promise/prefer-await-to-callbacks
         lastFileProcessed = B.try(async () => await callback(item.path, item.stats.isDirectory()))
           .then(shouldResolve => {
@@ -109,10 +122,13 @@ let fs = {
           });
       })
       .on('error', (err, item) => log.warn(`Got an error while walking '${item.path}': ${err.message}`))
-      .on('end', () => {
+      .on('end', function () {
+        log.debug(`Traversed ${directoryCount} ${pluralize('directory', directoryCount)} ` +
+          `and ${fileCount} ${pluralize('file', fileCount)} ` +
+          `in ${timer.getDuration().asMilliSeconds.toFixed(0)}ms`);
         lastFileProcessed
-          .then(() => resolve(null))
-          .catch(err => log.warn(`Unexpected error: ${err.message}`));
+          .then(resolve)
+          .catch((err) => log.warn(`Unexpected error: ${err.message}`));
       });
     });
   }

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -88,13 +88,13 @@ let fs = {
       throw Error(`'${dir}' is not a valid root directory` + (errMsg ? `. Original error: ${errMsg}` : ''));
     }
 
-    return await new B((resolve, reject) => {
+    let walker;
+    let fileCount = 0;
+    let directoryCount = 0;
+    const timer = new Timer().start();
+    return await new B(function (resolve, reject) {
       let lastFileProcessed = B.resolve();
-      let fileCount = 0;
-      let directoryCount = 0;
-      const timer = new Timer().start();
-
-      const walker = klaw(dir, {
+      walker = klaw(dir, {
         depthLimit: recursive ? -1 : 0,
       });
       walker.on('data', function (item) {
@@ -108,28 +108,38 @@ let fs = {
 
         // eslint-disable-next-line promise/prefer-await-to-callbacks
         lastFileProcessed = B.try(async () => await callback(item.path, item.stats.isDirectory()))
-          .then(shouldResolve => {
-            if (shouldResolve) {
+          .then(function (done = false) {
+            if (done) {
               resolve(item.path);
-              walker.destroy();
             } else {
               walker.resume();
             }
           })
-          .catch(err => {
-            reject(err);
-            walker.destroy();
-          });
+          .catch(reject);
       })
-      .on('error', (err, item) => log.warn(`Got an error while walking '${item.path}': ${err.message}`))
+      .on('error', function (err, item) {
+        log.warn(`Got an error while walking '${item.path}': ${err.message}`);
+        // klaw cannot get back from an ENOENT error
+        if (err.code === 'ENOENT') {
+          log.warn('All files may not have been accessed');
+          reject(err);
+        }
+      })
       .on('end', function () {
-        log.debug(`Traversed ${directoryCount} ${pluralize('directory', directoryCount)} ` +
-          `and ${fileCount} ${pluralize('file', fileCount)} ` +
-          `in ${timer.getDuration().asMilliSeconds.toFixed(0)}ms`);
         lastFileProcessed
           .then(resolve)
-          .catch((err) => log.warn(`Unexpected error: ${err.message}`));
+          .catch(function (err) {
+            log.warn(`Unexpected error: ${err.message}`);
+            reject(err);
+          });
       });
+    }).finally(function () {
+      log.debug(`Traversed ${directoryCount} ${pluralize('directory', directoryCount)} ` +
+        `and ${fileCount} ${pluralize('file', fileCount)} ` +
+        `in ${timer.getDuration().asMilliSeconds.toFixed(0)}ms`);
+      if (walker) {
+        walker.destroy();
+      }
     });
   }
 };

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "ncp": "^2.0.0",
     "npmlog": "^4.1.2",
     "plist": "^3.0.1",
+    "pluralize": "^8.0.0",
     "pngjs": "^3.0.0",
     "request": "^2.83.0",
     "request-promise": "^4.2.2",

--- a/test/fs-specs.js
+++ b/test/fs-specs.js
@@ -3,6 +3,7 @@ import chai from 'chai';
 import path from 'path';
 import { exec } from 'teen_process';
 import B from 'bluebird';
+import _ from 'lodash';
 
 
 const should = chai.should();
@@ -176,9 +177,9 @@ describe('fs', function () {
 
       });
       inCallback.should.equal(0);
-      should.equal(filePath, null);
+      _.isNil(filePath).should.be.true;
     });
-    it('walkDir callback error', async function () {
+    it('should throw error through callback', async function () {
       let processed = 0;
       await chai.expect(fs.walkDir(__dirname, true,
         () => {
@@ -187,9 +188,9 @@ describe('fs', function () {
         })).to.be.rejectedWith('Callback error');
       processed.should.equal(1);
     });
-    it('walkDir not recursive', async function () {
+    it('should traverse non-recursively', async function () {
       const filePath = await fs.walkDir(__dirname, false, (item) => item.endsWith('logger/helpers.js'));
-      should.equal(filePath, null);
+      _.isNil(filePath).should.be.true;
     });
   });
 });


### PR DESCRIPTION
I was working on an issue with the removal of files, and there was no visibility into what this function was doing. So log the final output when things are done.