### PR TITLE
chore: add todo to get rid of mkdirp dep

### DIFF
--- a/lib/mkdirp.js
+++ b/lib/mkdirp.js
@@ -1,4 +1,9 @@
 import mkdirp from 'mkdirp';
 
+/**
+ * TODO: once we drop support for Node 10, this should be removed in favor
+ * of fs.mkdir(dir, {recursive: true});
+ */
+
 
 export { mkdirp };


### PR DESCRIPTION
Node 10.12 introduced the `recursive` option to `fs.mkdir`(https://nodejs.org/api/fs.html#fs_fs_mkdir_path_options_callback).