### PR TITLE
fix: when requiring globally, try direct path first

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -1,7 +1,7 @@
 import { isWindows } from './system';
 import log from './logger';
 import { exec } from 'teen_process';
-
+import path from 'path';
 
 /**
  * Internal utility to link global package to local context
@@ -36,14 +36,26 @@ async function linkGlobalPackage (packageName) {
  * @throws {Error} If the package is not found locally or globally
  */
 async function requirePackage (packageName) {
+  // first, get it in the normal way (see https://nodejs.org/api/modules.html#modules_all_together)
   try {
     log.debug(`Loading local package '${packageName}'`);
     return require(packageName);
   } catch (err) {
     log.debug(`Failed to load local package '${packageName}': ${err.message}`);
-    await linkGlobalPackage(packageName);
   }
+
+  // second, get it from where it ought to be in the global node_modules
   try {
+    const globalPackageName = path.resolve(process.env.npm_config_prefix, 'lib', 'node_modules', packageName);
+    log.debug(`Loading global package '${globalPackageName}'`);
+    return require(globalPackageName);
+  } catch (err) {
+    log.debug(`Failed to load global package '${packageName}': ${err.message}`);
+  }
+
+  // third, link the file and get locally
+  try {
+    await linkGlobalPackage(packageName);
     log.debug(`Retrying load of linked package '${packageName}'`);
     return require(packageName);
   } catch (err) {


### PR DESCRIPTION
Node 12 recently broke how were were accommodating global requires. This adds a step to try where the package ought to be as an absolute path.

This will fix the build, too.