### PR TITLE
feat: Perform fine-tuning of toInMemoryZip helper

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -389,6 +389,10 @@ function pluralize (word, count, options = {}) {
  * or the source file is too big to be read completely into the memory
  */
 async function toInMemoryBase64 (srcPath, opts = {}) {
+  if (!(await fs.exists(srcPath)) || (await fs.stat(srcPath)).isDirectory()) {
+    throw new Error(`No such file: ${srcPath}`);
+  }
+
   const {
     maxSize = 1 * GiB,
   } = opts;

--- a/lib/util.js
+++ b/lib/util.js
@@ -386,7 +386,7 @@ function pluralize (word, count, options = {}) {
  * @param {EncodingOptions} opts
  * @returns {Buffer} base64-encoded content of the source file as memory buffer
  * @throws {Error} if there was an error while reading the source file
- * or the source file is too big to be read completely into the memory
+ * or the source file is too
  */
 async function toInMemoryBase64 (srcPath, opts = {}) {
   if (!(await fs.exists(srcPath)) || (await fs.stat(srcPath)).isDirectory()) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -6,9 +6,11 @@ import fs from './fs';
 import semver from 'semver';
 import { quote as shellQuote } from 'shell-quote';
 import pluralizeLib from 'pluralize';
-
+import stream from 'stream';
+import { Base64Encode } from 'base64-stream';
 
 const W3C_WEB_ELEMENT_IDENTIFIER = 'element-6066-11e4-a52e-4f735466cecf';
+const GiB = 1024 * 1024 * 1024;
 
 export function hasContent (val) {
   return _.isString(val) && val !== '';
@@ -208,8 +210,8 @@ function toReadableSizeString (bytes) {
   if (isNaN(intBytes) || intBytes < 0) {
     throw new Error(`Cannot convert '${bytes}' to a readable size format`);
   }
-  if (intBytes >= 1024 * 1024 * 1024) {
-    return `${parseFloat(intBytes / (1024 * 1024 * 1024.0)).toFixed(2)} GB`;
+  if (intBytes >= GiB) {
+    return `${parseFloat(intBytes / (GiB * 1.0)).toFixed(2)} GB`;
   } else if (intBytes >= 1024 * 1024) {
     return `${parseFloat(intBytes / (1024 * 1024.0)).toFixed(2)} MB`;
   } else if (intBytes >= 1024) {
@@ -366,10 +368,71 @@ function pluralize (word, count, options = {}) {
   return pluralizeLib(word, count, inclusive);
 }
 
+/**
+ * @typedef {Object} EncodingOptions
+ * @property {number} maxSize [1073741824] The maximum size of
+ * the resulting buffer in bytes. This is set to 1GB by default, because
+ * Appium limits the maximum HTTP body size to 1GB. Also, the NodeJS heap
+ * size must be enough to keep the resulting object (usually this size is
+ * limited to 1.4 GB)
+ */
+
+/**
+ * Converts contents of a local file to an in-memory base-64 encoded buffer.
+ * The operation is memory-usage friendly and should be used while encoding
+ * large files to base64
+ *
+ * @param {string} srcPath The full path to the file being encoded
+ * @param {EncodingOptions} opts
+ * @returns {Buffer} base64-encoded content of the source file as memory buffer
+ * @throws {Error} if there was an error while reading the source file
+ * or the source file is too big to be read completely into the memory
+ */
+async function toInMemoryBase64 (srcPath, opts = {}) {
+  const {
+    maxSize = 1 * GiB,
+  } = opts;
+  const resultBuffers = [];
+  let resultBuffersSize = 0;
+  const resultWriteStream = new stream.Writable({
+    write: (buffer, encoding, next) => {
+      resultBuffers.push(buffer);
+      resultBuffersSize += buffer.length;
+      if (maxSize > 0 && resultBuffersSize > maxSize) {
+        resultWriteStream.emit('error', new Error(`The size of the resulting ` +
+          `buffer must not be greater than ${toReadableSizeString(maxSize)}`));
+      }
+      next();
+    },
+  });
+
+  const readerStream = fs.createReadStream(srcPath);
+  const base64EncoderStream = new Base64Encode();
+  const resultWriteStreamPromise = new B((resolve, reject) => {
+    resultWriteStream.once('error', (e) => {
+      readerStream.unpipe(base64EncoderStream);
+      base64EncoderStream.unpipe(resultWriteStream);
+      readerStream.destroy();
+      reject(e);
+    });
+    resultWriteStream.once('finish', resolve);
+  });
+  const readStreamPromise = new B((resolve, reject) => {
+    readerStream.once('close', resolve);
+    readerStream.once('error', (e) => reject(
+      new Error(`Failed to read '${srcPath}': ${e.message}`)));
+  });
+  readerStream.pipe(base64EncoderStream);
+  base64EncoderStream.pipe(resultWriteStream);
+
+  await B.all([readStreamPromise, resultWriteStreamPromise]);
+  return Buffer.concat(resultBuffers);
+}
+
 export {
   hasValue, escapeSpace, escapeSpecialChars, localIp, cancellableDelay,
   multiResolve, safeJsonParse, wrapElement, unwrapElement, filterObject,
   toReadableSizeString, isSubPath, W3C_WEB_ELEMENT_IDENTIFIER,
   isSameDestination, compareVersions, coerceVersion, quote, unleakString,
-  jsonStringify, pluralize,
+  jsonStringify, pluralize, GiB, toInMemoryBase64,
 };

--- a/lib/zip.js
+++ b/lib/zip.js
@@ -207,8 +207,9 @@ async function toInMemoryZip (srcPath, opts = {}) {
   await B.all([archiveStreamPromise, resultWriteStreamPromise]);
 
   if (timer) {
-    log.debug(`Compressed ${encodeToBase64 ? 'and base64-encoded ' : ''}` +
-      `'${srcPath}' in ${timer.getDuration().asSeconds.toFixed(3)}s`);
+    log.debug(`Zipped ${encodeToBase64 ? 'and base64-encoded ' : ''}` +
+      `'${srcPath}' in ${timer.getDuration().asSeconds.toFixed(3)}s ` +
+      `(compression level: ${level})`);
   }
   // Return the array of zip buffers concatenated into one buffer
   return Buffer.concat(resultBuffers);

--- a/lib/zip.js
+++ b/lib/zip.js
@@ -128,11 +128,11 @@ async function readEntries (zipFilePath, onEntry) {
 /**
  * Converts contents of local directory to an in-memory .zip buffer
  *
- * @param {string} srcDir The full path to the folder being zipped
+ * @param {string} srcPath The full path to the folder or file being zipped
  * @param {ZipOptions} opts Zipping options
  * @returns {Buffer} Zipped content of the source folder as memory buffer
  */
-async function toInMemoryZip (srcDir, opts = {}) {
+async function toInMemoryZip (srcPath, opts = {}) {
   const {
     encodeToBase64 = false,
     maxSize = 1 * GiB,
@@ -166,6 +166,7 @@ async function toInMemoryZip (srcDir, opts = {}) {
       } else {
         archive.unpipe(resultWriteStream);
       }
+      archive.abort();
       archive.destroy();
       reject(e);
     });
@@ -174,9 +175,15 @@ async function toInMemoryZip (srcDir, opts = {}) {
   const archiveStreamPromise = new B((resolve, reject) => {
     archive.once('finish', resolve);
     archive.once('error', (e) => reject(
-      new Error(`Failed to archive the directory '${srcDir}': ${e.message}`)));
+      new Error(`Failed to archive '${srcPath}': ${e.message}`)));
   });
-  archive.directory(srcDir, false);
+  if ((await fs.stat(srcPath)).isDirectory()) {
+    archive.directory(srcPath, false);
+  } else {
+    archive.file(srcPath, {
+      name: path.basename(srcPath),
+    });
+  }
   if (base64EncoderStream) {
     archive.pipe(base64EncoderStream);
     base64EncoderStream.pipe(resultWriteStream);

--- a/lib/zip.js
+++ b/lib/zip.js
@@ -8,12 +8,11 @@ import { mkdirp } from '../lib/mkdirp';
 import stream from 'stream';
 import fs from './fs';
 import { Base64Encode } from 'base64-stream';
-import { toReadableSizeString } from './util';
+import { toReadableSizeString, GiB } from './util';
 
 const extract = B.promisify(nodeExtract);
 const open = B.promisify(yauzl.open);
 const ZIP_MAGIC = 'PK';
-const GiB = 1024 * 1024 * 1024;
 
 /**
  * Extract zipfile to a directory
@@ -131,6 +130,8 @@ async function readEntries (zipFilePath, onEntry) {
  * @param {string} srcPath The full path to the folder or file being zipped
  * @param {ZipOptions} opts Zipping options
  * @returns {Buffer} Zipped content of the source folder as memory buffer
+ * @throws {Error} if there was an error while reading the source
+ * or the source is too big to be read completely into the memory
  */
 async function toInMemoryZip (srcPath, opts = {}) {
   const {

--- a/lib/zip.js
+++ b/lib/zip.js
@@ -288,7 +288,12 @@ async function toArchive (dstPath, src = {}, opts = {}) {
       .on('error', reject)
       .pipe(stream);
     stream
-      .on('error', reject)
+      .on('error', (e) => {
+        archive.unpipe(stream);
+        archive.abort();
+        archive.destroy();
+        reject(e);
+      })
       .on('close', resolve);
     archive.finalize();
   });

--- a/lib/zip.js
+++ b/lib/zip.js
@@ -287,7 +287,9 @@ async function toArchive (dstPath, src = {}, opts = {}) {
       })
       .on('error', reject)
       .pipe(stream);
-    stream.on('close', resolve);
+    stream
+      .on('error', reject)
+      .on('close', resolve);
     archive.finalize();
   });
 }

--- a/lib/zip.js
+++ b/lib/zip.js
@@ -133,9 +133,10 @@ async function readEntries (zipFilePath, onEntry) {
  *
  * @param {string} srcPath The full path to the folder or file being zipped
  * @param {ZipOptions} opts Zipping options
- * @returns {Buffer} Zipped content of the source folder as memory buffer
+ * @returns {Buffer} Zipped (and encoded if `encodeToBase64` is truthy)
+ * content of the source path as memory buffer
  * @throws {Error} if there was an error while reading the source
- * or the source is too big to be read completely into the memory
+ * or the source is too big
  */
 async function toInMemoryZip (srcPath, opts = {}) {
   if (!await fs.exists(srcPath)) {

--- a/lib/zip.js
+++ b/lib/zip.js
@@ -9,6 +9,8 @@ import stream from 'stream';
 import fs from './fs';
 import { Base64Encode } from 'base64-stream';
 import { toReadableSizeString, GiB } from './util';
+import Timer from './timing';
+import log from './logger';
 
 const extract = B.promisify(nodeExtract);
 const open = B.promisify(yauzl.open);
@@ -114,6 +116,8 @@ async function readEntries (zipFilePath, onEntry) {
  * @typedef {Object} ZipOptions
  * @property {boolean} encodeToBase64 [false] Whether to encode
  * the resulting archive to a base64-encoded string
+ * @property {boolean} isMetered [true] Whether to log the actual
+ * archiver performance
  * @property {number} maxSize [1073741824] The maximum size of
  * the resulting archive in bytes. This is set to 1GB by default, because
  * Appium limits the maximum HTTP body size to 1GB. Also, the NodeJS heap
@@ -139,6 +143,7 @@ async function toInMemoryZip (srcPath, opts = {}) {
   }
 
   const {
+    isMetered = true,
     encodeToBase64 = false,
     maxSize = 1 * GiB,
     level = 9,
@@ -158,6 +163,7 @@ async function toInMemoryZip (srcPath, opts = {}) {
     },
   });
 
+  const timer = isMetered ? new Timer().start() : null;
   // Zip 'srcDir' and stream it to the above writable stream
   const archive = archiver('zip', {
     zlib: {level}
@@ -200,6 +206,10 @@ async function toInMemoryZip (srcPath, opts = {}) {
   // Wait for the streams to finish
   await B.all([archiveStreamPromise, resultWriteStreamPromise]);
 
+  if (timer) {
+    log.debug(`Compressed ${encodeToBase64 ? 'and base64-encoded ' : ''}` +
+      `'${srcPath}' in ${timer.getDuration().asSeconds.toFixed(3)}s`);
+  }
   // Return the array of zip buffers concatenated into one buffer
   return Buffer.concat(resultBuffers);
 }

--- a/lib/zip.js
+++ b/lib/zip.js
@@ -178,9 +178,8 @@ async function toInMemoryZip (srcDir, opts = {}) {
   });
   archive.directory(srcDir, false);
   if (base64EncoderStream) {
-    archive
-      .pipe(base64EncoderStream)
-      .pipe(resultWriteStream);
+    archive.pipe(base64EncoderStream);
+    base64EncoderStream.pipe(resultWriteStream);
   } else {
     archive.pipe(resultWriteStream);
   }

--- a/lib/zip.js
+++ b/lib/zip.js
@@ -7,10 +7,13 @@ import path from 'path';
 import { mkdirp } from '../lib/mkdirp';
 import stream from 'stream';
 import fs from './fs';
+import { Base64Encode } from 'base64-stream';
+import { toReadableSizeString } from './util';
 
 const extract = B.promisify(nodeExtract);
 const open = B.promisify(yauzl.open);
 const ZIP_MAGIC = 'PK';
+const GiB = 1024 * 1024 * 1024;
 
 /**
  * Extract zipfile to a directory
@@ -109,42 +112,85 @@ async function readEntries (zipFilePath, onEntry) {
 }
 
 /**
+ * @typedef {Object} ZipOptions
+ * @property {boolean} encodeToBase64 [false] Whether to encode
+ * the resulting archive to base64 string
+ * @property {number} maxSize [1073741824] The maximum size of
+ * the resulting archive in bytes. This is set to 1GB by default, because
+ * Appium limits the maximum HTTP body size to 1GB. Also, the NodeJS heap
+ * size must be enough to keep the resulting object (usually this size is
+ * limited to 1.4 GB)
+ * @property {number} level [9] The compression level. The maximum
+ * level is 9 (the best compression, worst performance). The minimum
+ * compression level is 0 (no compression).
+ */
+
+/**
  * Converts contents of local directory to an in-memory .zip buffer
  *
  * @param {string} srcDir The full path to the folder being zipped
+ * @param {ZipOptions} opts Zipping options
  * @returns {Buffer} Zipped content of the source folder as memory buffer
  */
-async function toInMemoryZip (srcDir) {
+async function toInMemoryZip (srcDir, opts = {}) {
+  const {
+    encodeToBase64 = false,
+    maxSize = 1 * GiB,
+    level = 9,
+  } = opts;
+  const resultBuffers = [];
+  let resultBuffersSize = 0;
   // Create a writable stream that zip buffers will be streamed to
-  const zipBufferArr = [];
-  const zipWriteStream = new stream.Writable({
+  const resultWriteStream = new stream.Writable({
     write: (buffer, encoding, next) => {
-      zipBufferArr.push(buffer);
+      resultBuffers.push(buffer);
+      resultBuffersSize += buffer.length;
+      if (maxSize > 0 && resultBuffersSize > maxSize) {
+        resultWriteStream.emit('error', new Error(`The size of the resulting ` +
+          `archive must not be greater than ${toReadableSizeString(maxSize)}`));
+      }
       next();
     },
-  });
-  const zipWriteStreamPromise = new B((resolve) => {
-    // Don't need to do error handling since this writeStream is in-memory and doesn't emit any errors
-    zipWriteStream.once('finish', resolve);
   });
 
   // Zip 'srcDir' and stream it to the above writable stream
   const archive = archiver('zip', {
-    zlib: {level: 9}
+    zlib: {level}
+  });
+  const base64EncoderStream = encodeToBase64 ? new Base64Encode() : null;
+  const resultWriteStreamPromise = new B((resolve, reject) => {
+    resultWriteStream.once('error', (e) => {
+      if (base64EncoderStream) {
+        archive.unpipe(base64EncoderStream);
+        base64EncoderStream.unpipe(resultWriteStream);
+      } else {
+        archive.unpipe(resultWriteStream);
+      }
+      archive.destroy();
+      reject(e);
+    });
+    resultWriteStream.once('finish', resolve);
   });
   const archiveStreamPromise = new B((resolve, reject) => {
     archive.once('finish', resolve);
-    archive.once('error', (errStr) => reject(new Error(`Failed to zip directory ${srcDir}: ${errStr}`)));
+    archive.once('error', (e) => reject(
+      new Error(`Failed to archive the directory '${srcDir}': ${e.message}`)));
   });
   archive.directory(srcDir, false);
-  archive.pipe(zipWriteStream);
+  if (base64EncoderStream) {
+    archive
+      .pipe(base64EncoderStream)
+      .pipe(resultWriteStream);
+  } else {
+    archive.pipe(resultWriteStream);
+  }
   archive.finalize();
 
   // Wait for the streams to finish
-  await B.all([archiveStreamPromise, zipWriteStreamPromise]);
+  await B.all([archiveStreamPromise, resultWriteStreamPromise]);
 
   // Return the array of zip buffers concatenated into one buffer
-  return Buffer.concat(zipBufferArr);
+  return Buffer.concat(resultBuffers);
 }
 
 /**

--- a/lib/zip.js
+++ b/lib/zip.js
@@ -163,7 +163,6 @@ async function toInMemoryZip (srcPath, opts = {}) {
     },
   });
 
-  const timer = isMetered ? new Timer().start() : null;
   // Zip 'srcDir' and stream it to the above writable stream
   const archive = archiver('zip', {
     zlib: {level}
@@ -188,6 +187,7 @@ async function toInMemoryZip (srcPath, opts = {}) {
     archive.once('error', (e) => reject(
       new Error(`Failed to archive '${srcPath}': ${e.message}`)));
   });
+  const timer = isMetered ? new Timer().start() : null;
   if ((await fs.stat(srcPath)).isDirectory()) {
     archive.directory(srcPath, false);
   } else {

--- a/lib/zip.js
+++ b/lib/zip.js
@@ -113,7 +113,7 @@ async function readEntries (zipFilePath, onEntry) {
 /**
  * @typedef {Object} ZipOptions
  * @property {boolean} encodeToBase64 [false] Whether to encode
- * the resulting archive to base64 string
+ * the resulting archive to a base64-encoded string
  * @property {number} maxSize [1073741824] The maximum size of
  * the resulting archive in bytes. This is set to 1GB by default, because
  * Appium limits the maximum HTTP body size to 1GB. Also, the NodeJS heap

--- a/lib/zip.js
+++ b/lib/zip.js
@@ -134,6 +134,10 @@ async function readEntries (zipFilePath, onEntry) {
  * or the source is too big to be read completely into the memory
  */
 async function toInMemoryZip (srcPath, opts = {}) {
+  if (!await fs.exists(srcPath)) {
+    throw new Error(`No such file or folder: ${srcPath}`);
+  }
+
   const {
     encodeToBase64 = false,
     maxSize = 1 * GiB,

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "archiver": "^1.3.0",
+    "base64-stream": "^1.0.0",
     "bluebird": "^3.5.1",
     "bplist-creator": "^0",
     "bplist-parser": "^0.2",

--- a/test/util-e2e-specs.js
+++ b/test/util-e2e-specs.js
@@ -1,0 +1,36 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import path from 'path';
+import * as util from '../lib/util';
+import { tempDir, fs } from '../index';
+
+
+chai.use(chaiAsPromised);
+
+describe('#util', function () {
+  let tmpRoot;
+  let tmpFile;
+  const content = 'YOLO';
+
+  beforeEach(async function () {
+    tmpRoot = await tempDir.openDir();
+    tmpFile = path.resolve(tmpRoot, 'example.txt');
+    await fs.writeFile(tmpFile, content, 'utf8');
+  });
+
+  afterEach(async function () {
+    if (tmpRoot) {
+      await fs.rimraf(tmpRoot);
+    }
+    tmpRoot = null;
+  });
+
+  describe('toInMemoryBase64()', function () {
+    it('should convert a file to base64 encoding', async function () {
+      const data = await util.toInMemoryBase64(tmpFile);
+      const fileContent = await fs.readFile(tmpFile);
+      data.toString().should.eql(fileContent.toString('base64'));
+    });
+  });
+
+});

--- a/test/zip-e2e-specs.js
+++ b/test/zip-e2e-specs.js
@@ -115,7 +115,7 @@ describe('#zip', function () {
         encodeToBase64: true,
       });
 
-      await fs.writeFile(path.resolve(tmpRoot, 'test.zip'), Buffer.from(buffer, 'base64'));
+      await fs.writeFile(path.resolve(tmpRoot, 'test.zip'), Buffer.from(buffer.toString(), 'base64'));
 
       // Unzip the file and test that it has the same contents as the directory that was zipped
       await zip.extractAllTo(path.resolve(tmpRoot, 'test.zip'), path.resolve(tmpRoot, 'output'));

--- a/test/zip-e2e-specs.js
+++ b/test/zip-e2e-specs.js
@@ -129,7 +129,7 @@ describe('#zip', function () {
 
     it('should be rejected if use a bad path', async function () {
       await zip.toInMemoryZip(path.resolve(assetsPath, 'bad_path'))
-        .should.be.rejectedWith(/no such/);
+        .should.be.rejectedWith(/no such/i);
     });
 
     it('should be rejected if max size is exceeded', async function () {

--- a/test/zip-e2e-specs.js
+++ b/test/zip-e2e-specs.js
@@ -110,8 +110,25 @@ describe('#zip', function () {
       }).should.eventually.equal('Foo Bar');
     });
 
+    it('should convert a local folder to an in-memory base64-encoded zip buffer', async function () {
+      const testFolder = path.resolve(assetsPath, 'unzipped');
+      const buffer = await zip.toInMemoryZip(testFolder, {
+        encodeToBase64: true,
+        level: 6,
+      });
+      Buffer.from(buffer, 'base64').toString('base64').should.eql(buffer.toString());
+    });
+
     it('should be rejected if use a bad path', async function () {
-      await zip.toInMemoryZip(path.resolve(assetsPath, 'bad_path')).should.be.rejectedWith(/Failed to zip/);
+      await zip.toInMemoryZip(path.resolve(assetsPath, 'bad_path'))
+        .should.be.rejectedWith(/Failed to zip/);
+    });
+
+    it('should be rejected if max size is exceeded', async function () {
+      const testFolder = path.resolve(assetsPath, 'unzipped');
+      await zip.toInMemoryZip(testFolder, {
+        maxSize: 1,
+      }).should.be.rejectedWith(/must not be greater/);
     });
 
     it('should be rejected if there is no access to the directory', async function () {


### PR DESCRIPTION
Streamed base64 encoding will help to save memory, since sometimes the amount of data passed to `toInMemoryZip` helper is super large. Also having some precautions like maxSize wouldn't hurt us in any case