### PR TITLE
feat: Add primitives for uuid generation

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -4,13 +4,25 @@ import os from 'os';
 import path from 'path';
 import fs from './fs';
 import semver from 'semver';
-import { quote as shellQuote } from 'shell-quote';
+import {
+  // https://www.npmjs.com/package/shell-quote
+  quote as shellQuote,
+  parse as shellParse,
+} from 'shell-quote';
 import pluralizeLib from 'pluralize';
 import stream from 'stream';
 import { Base64Encode } from 'base64-stream';
+import {
+  // https://www.npmjs.com/package/uuid
+  v1 as uuidV1, v3 as uuidV3,
+  v4 as uuidV4, v5 as uuidV5
+} from 'uuid';
+
 
 const W3C_WEB_ELEMENT_IDENTIFIER = 'element-6066-11e4-a52e-4f735466cecf';
-const GiB = 1024 * 1024 * 1024;
+const KiB = 1024;
+const MiB = KiB * 1024;
+const GiB = MiB * 1024;
 
 export function hasContent (val) {
   return _.isString(val) && val !== '';
@@ -212,10 +224,10 @@ function toReadableSizeString (bytes) {
   }
   if (intBytes >= GiB) {
     return `${parseFloat(intBytes / (GiB * 1.0)).toFixed(2)} GB`;
-  } else if (intBytes >= 1024 * 1024) {
-    return `${parseFloat(intBytes / (1024 * 1024.0)).toFixed(2)} MB`;
-  } else if (intBytes >= 1024) {
-    return `${parseFloat(intBytes / 1024.0).toFixed(2)} KB`;
+  } else if (intBytes >= MiB) {
+    return `${parseFloat(intBytes / (MiB * 1.0)).toFixed(2)} MB`;
+  } else if (intBytes >= KiB) {
+    return `${parseFloat(intBytes / (KiB * 1.0)).toFixed(2)} KB`;
   }
   return `${intBytes} B`;
 }
@@ -438,5 +450,6 @@ export {
   multiResolve, safeJsonParse, wrapElement, unwrapElement, filterObject,
   toReadableSizeString, isSubPath, W3C_WEB_ELEMENT_IDENTIFIER,
   isSameDestination, compareVersions, coerceVersion, quote, unleakString,
-  jsonStringify, pluralize, GiB, toInMemoryBase64,
+  jsonStringify, pluralize, GiB, MiB, KiB, toInMemoryBase64,
+  uuidV1, uuidV3, uuidV4, uuidV5, shellParse,
 };

--- a/package.json
+++ b/package.json
@@ -55,8 +55,10 @@
     "request-promise": "^4.2.2",
     "rimraf": "^3.0.0",
     "semver": "^7.0.0",
+    "shell-quote": "^1.7.2",
     "source-map-support": "^0.5.5",
     "teen_process": "^1.5.1",
+    "uuid": "^7.0.2",
     "which": "^2.0.0",
     "yauzl": "^2.7.0"
   },


### PR DESCRIPTION
I can observe that different libs for uuids generation are being imported by different Appium modules (for example the outdated uuid-js). They must be unified and be accessible from appium-support instead.