### PR TITLE
chore: dependabot do not update extract-zip

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,3 +3,7 @@ update_configs:
   - package_manager: "javascript"
     directory: "/"
     update_schedule: "live"
+    ignored_updates:
+      - match:
+          # remove this when Appium drops Node 10 support
+          dependency_name: "extract-zip"


### PR DESCRIPTION
`extract-zip@2.0.0` removed support for Node < 10.12 (https://github.com/maxogden/extract-zip/releases/tag/v2.0.0). Since Appium supports 10 (until the fall, assuming Node keeps its normal release cadence during this time) we cannot update.