### PR TITLE
fix: Exclude the recorded video contents from the log

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -60,10 +60,12 @@ async function uploadFileToHttp (localFileStream, parsedUri, uploadOptions = {})
       }
     }
   }
-  requestOpts.data = form;
   requestOpts.headers = Object.assign({}, _.isPlainObject(headers) ? headers : {}, form.getHeaders());
 
-  log.debug(`${protocol} upload options: ${JSON.stringify(requestOpts)}`);
+  // exclude form data from the log since it'll contain the entire recorded video
+  log.debug(`${protocol} upload options (ex. form data): ${JSON.stringify(requestOpts)}`);
+  requestOpts.data = form;
+
   await axios(requestOpts);
 }
 


### PR DESCRIPTION
This skips logging the contents of the screen recording video to the debug log.
The video is massive and outputting it to the debug log in a integer array format both slows down (or crashes) the process and limits the usability of the logs.