### PR TITLE
fix: Specify node version > 10.0.0 

### DIFF
--- a/lib/zip.js
+++ b/lib/zip.js
@@ -13,6 +13,10 @@ import Timer from './timing';
 import log from './logger';
 import getStream from 'get-stream';
 
+if (!stream.pipeline) {
+  throw new Error(`Please use node with version > v10.x, now you use the version: ${process.version}`);
+}
+
 const openZip = B.promisify(yauzl.open);
 const pipeline = B.promisify(stream.pipeline);
 const ZIP_MAGIC = 'PK';

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   "bugs": {
     "url": "https://github.com/appium/appium-support/issues"
   },
-  "engines": [
-    "node"
-  ],
+  "engines": {
+    "node": ">=10.0.0"
+  },
   "main": "./build/index.js",
   "bin": {},
   "directories": {


### PR DESCRIPTION
The [stream pipeline api](https://nodejs.org/docs/latest-v8.x/api/stream.html) is not supported in node version 8.x.

We should tell the user it's not supported

Otherwise, when we use the bluebird promisify api, we get the error

```
expecting a function but got [object Undefined]
```