### PR TITLE
feat: Add an option to recover a "broken" file lock

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -470,7 +470,6 @@ function getLockFileGuard (lockFile, opts = {}) {
   const lock = B.promisify(_lockfile.lock);
   const check = B.promisify(_lockfile.check);
   const unlock = B.promisify(_lockfile.unlock);
-  const lockOpts = {wait: timeout * 1000};
 
   const guard = async (behavior) => {
     let triedRecovery = false;
@@ -480,9 +479,9 @@ function getLockFileGuard (lockFile, opts = {}) {
         // on the same spin of the event loop can also initiate a lock. If the lockfile does exist
         // then just use the regular async 'lock' method which will wait on the lock.
         if (_lockfile.checkSync(lockFile)) {
-          await lock(lockFile, lockOpts);
+          await lock(lockFile, {wait: timeout * 1000});
         } else {
-          _lockfile.lockSync(lockFile, lockOpts);
+          _lockfile.lockSync(lockFile);
         }
         break;
       } catch (e) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -446,8 +446,11 @@ async function toInMemoryBase64 (srcPath, opts = {}) {
 
 /**
  * @typedef {Object} LockFileOptions
- * @param {number} timeout [120] The max time in seconds to wait for the lock
+ * @property {number} timeout [120] The max time in seconds to wait for the lock
+ * @property {boolean} tryRecovery [false] Whether to try lock recovery if
+ * the first attempt to acquire it timed out.
  */
+
 /**
  * Create an async function which, when called, will not proceed until a certain file is no
  * longer present on the system. This allows for preventing concurrent behavior across processes
@@ -458,33 +461,43 @@ async function toInMemoryBase64 (srcPath, opts = {}) {
  * @returns {AsyncFunction} async function that takes another async function defining the locked
  * behavior
  */
-function getLockFileGuard (lockFile, opts = {timeout: 120}) {
+function getLockFileGuard (lockFile, opts = {}) {
+  const {
+    timeout = 120,
+    tryRecovery = false,
+  } = opts;
+
   const lock = B.promisify(_lockfile.lock);
-  const performLock = async () => await lock(lockFile, {wait: opts.timeout * 1000});
   const check = B.promisify(_lockfile.check);
   const unlock = B.promisify(_lockfile.unlock);
+  const lockOpts = {wait: timeout * 1000};
 
   const guard = async (behavior) => {
-    try {
-      // if the lockfile doesn't exist, lock it synchronously to make sure no other call
-      // on the same spin of the event loop can also initiate a lock. If the lockfile does exist
-      // then just use the regular async 'lock' method which will wait on the lock.
-      if (!_lockfile.checkSync(lockFile)) {
-        try {
-          _lockfile.lockSync(lockFile);
-        } catch (e) {
-          // Avoid cross-process race condition
-          if (!_.includes(e.message, 'EEXIST')) {
-            throw e;
-          }
-          await performLock();
+    let triedRecovery = false;
+    do {
+      try {
+        // if the lockfile doesn't exist, lock it synchronously to make sure no other call
+        // on the same spin of the event loop can also initiate a lock. If the lockfile does exist
+        // then just use the regular async 'lock' method which will wait on the lock.
+        if (_lockfile.checkSync(lockFile)) {
+          await lock(lockFile, lockOpts);
+        } else {
+          _lockfile.lockSync(lockFile, lockOpts);
         }
-      } else {
-        await performLock();
+        break;
+      } catch (e) {
+        if (_.includes(e.message, 'EEXIST') && tryRecovery && !triedRecovery) {
+          // There could be cases where a process has been forcefully terminated
+          // without a chance to clean up pending locks: https://github.com/npm/lockfile/issues/26
+          _lockfile.unlockSync(lockFile);
+          triedRecovery = true;
+          continue;
+        }
+        throw new Error(`Could not acquire lock on '${lockFile}' after ${timeout}s. ` +
+          `Original error: ${e.message}`);
       }
-    } catch (e) {
-      throw new Error(`Could not acquire lock on ${lockFile}. Original error: ${e}`);
-    }
+    // eslint-disable-next-line no-constant-condition
+    } while (true);
     try {
       return await behavior();
     } finally {


### PR DESCRIPTION
There could be cases where a process has been forcefully terminated without a chance to clean up pending locks: https://github.com/npm/lockfile/issues/26