### PR TITLE
fix: Make sure we don't get an outdated screenshot if there was an error in MJPEG consumer

### DIFF
--- a/lib/mjpeg.js
+++ b/lib/mjpeg.js
@@ -127,6 +127,9 @@ class MJpegStream extends Writable {
         `Waited ${serverTimeout}ms but the MJPEG server never sent any images`);
 
     const onErr = (err) => {
+      // Make sure we don't get an outdated screenshot if there was an error
+      this.lastChunk = null;
+
       log.error(`Error getting MJpeg screenshot chunk: ${err.message}`);
       this.errorHandler(err);
       if (this.registerStartFailure) {


### PR DESCRIPTION
Related to https://github.com/appium/appium/issues/15209