### PR TITLE
chore: try/catch in matchTemplateAsync for error message

### DIFF
--- a/lib/image-util.js
+++ b/lib/image-util.js
@@ -370,7 +370,7 @@ async function getImagesSimilarity (img1Data, img2Data, options = {}) {
   try {
     matched = await reference.matchTemplateAsync(template, cv.TM_CCOEFF_NORMED);
   } catch (e) {
-    throw new Error(`Both images did not match. Original error: ${e.message}`);
+    throw new Error(`The reference image did not match to the template one. Original error: ${e.message}`);
   }
   const minMax = await matched.minMaxLocAsync();
   const result = {

--- a/lib/image-util.js
+++ b/lib/image-util.js
@@ -366,7 +366,12 @@ async function getImagesSimilarity (img1Data, img2Data, options = {}) {
     reference.convertToAsync(cv.CV_8UC3)
   ]);
 
-  const matched = await reference.matchTemplateAsync(template, cv.TM_CCOEFF_NORMED);
+  let matched;
+  try {
+    matched = await reference.matchTemplateAsync(template, cv.TM_CCOEFF_NORMED);
+  } catch (e) {
+    throw new Error(`Both images did not match. Original error: ${e.message}`);
+  }
   const minMax = await matched.minMaxLocAsync();
   const result = {
     score: minMax.maxVal


### PR DESCRIPTION
Closes https://github.com/appium/appium-support/issues/220
When `matchTemplateAsync` fails, `getImageOccurrence` raises an error message which is `Cannot find any occurrences of the partial image in the full image`, meanwhile `getImagesSimilarity` returns no message. As a client, it only gets 'internal server error' with `undefined` error message.

It seems `e.message` by opencv4nodejs is usually `undefined`.

In addition to it, server-side message is like the below.

```
[debug] Support Loading local package 'opencv4nodejs'
[debug] [W3C (f7b505ad)] Encountered internal error running command: undefined
HTTP] <-- POST /wd/hub/session/f7b505ad-2e91-417b-86ea-e78ea94d1609/appium/compare_images 500 142 ms - 527
[HTTP]
```

So, i'd like to add more messages about no matched images there.
(Rarely the `e.message` had opencv error message, but I observed the case a few times in 10 to 20 times try.)