### PR TITLE
refactor: Try to load opencv4nodejs from the working fork by default

### DIFF
--- a/lib/image-util.js
+++ b/lib/image-util.js
@@ -126,17 +126,20 @@ async function initOpenCV () {
     return;
   }
 
-  log.debug(`Initializing opencv`);
-  try {
-    cv = await requirePackage('opencv4nodejs');
-  } catch (err) {
-    log.warn(`Unable to load 'opencv4nodejs': ${err.message}`);
+  log.debug(`Initializing OpenCV`);
+  for (const pkgName of ['@u4/opencv4nodejs', 'opencv4nodejs']) {
+    try {
+      cv = await requirePackage(pkgName);
+    } catch (err) {
+      log.warn(`Unable to load '${pkgName}': ${err.message}`);
+    }
   }
 
   if (!cv) {
-    throw new Error(`'opencv4nodejs' module is required to use OpenCV features. ` +
-                    `Please install it first ('npm i -g opencv4nodejs') and restart Appium. ` +
-                    'Read https://github.com/justadudewhohacks/opencv4nodejs#how-to-install for more details on this topic.');
+    throw new Error(`'@u4/opencv4nodejs' module is required to use OpenCV features. ` +
+      `Please install it first and restart Appium. ` +
+      `Read https://github.com/appium/appium-plugins/pull/73#issuecomment-1013683074 and ` +
+      `https://github.com/UrielCh/opencv4nodejs#fork-changes for more details on this topic.`);
   }
 }
 


### PR DESCRIPTION
The original repository is not maintained, so one might get a hard time now if try to compile and link an older OpenCV version to it. The fork at https://www.npmjs.com/package/@u4/opencv4nodejs updates basic deps, so now it is possible to use the most recent OpenCV releases.